### PR TITLE
Time Zone Fix for Messages

### DIFF
--- a/src/main/java/de/btobastian/javacord/entities/message/impl/ImplMessage.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/impl/ImplMessage.java
@@ -116,7 +116,7 @@ public class ImplMessage implements Message {
             String time = data.getString("timestamp");
             Calendar calendar = Calendar.getInstance();
             try {
-                //remove the nano seconds, rejoining on +. If the formatting change the string will remain the same
+                //remove the nano seconds, rejoining on +. If the formatting changes then the string will remain the same
                 String nanoSecondsRemoved = Joiner.on("+").join(time.split("\\d{3}\\+"));
                 calendar.setTime(TIMEZONE_FORMAT.get().parse(nanoSecondsRemoved));
             } catch (ParseException timeZoneIgnored) {


### PR DESCRIPTION
Issue #16 fix, now including TimeZone parsing. Using Regexp and Google Joiner to remove the nano seconds and make it milli seconds (for Java 7) . Test completed on quick tests + my bot. 