### PR TITLE
Renamed DiscordWebsocketAdapter to DiscordWebSocketAdapter

### DIFF
--- a/src/main/java/de/btobastian/javacord/DiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/DiscordApi.java
@@ -28,7 +28,7 @@ import de.btobastian.javacord.listeners.server.member.ServerMemberLeaveListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberUnbanListener;
 import de.btobastian.javacord.listeners.server.role.*;
 import de.btobastian.javacord.listeners.user.*;
-import de.btobastian.javacord.utils.DiscordWebsocketAdapter;
+import de.btobastian.javacord.utils.DiscordWebSocketAdapter;
 import de.btobastian.javacord.utils.ListenerManager;
 import de.btobastian.javacord.utils.ThreadPool;
 import de.btobastian.javacord.utils.ratelimits.RatelimitManager;
@@ -86,7 +86,7 @@ public interface DiscordApi {
      *
      * @return The websocket adapter.
      */
-    DiscordWebsocketAdapter getWebSocketAdapter();
+    DiscordWebSocketAdapter getWebSocketAdapter();
 
     /**
      * Gets the type of the current account.

--- a/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
@@ -31,7 +31,7 @@ import de.btobastian.javacord.listeners.server.member.ServerMemberLeaveListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberUnbanListener;
 import de.btobastian.javacord.listeners.server.role.*;
 import de.btobastian.javacord.listeners.user.*;
-import de.btobastian.javacord.utils.DiscordWebsocketAdapter;
+import de.btobastian.javacord.utils.DiscordWebSocketAdapter;
 import de.btobastian.javacord.utils.ListenerManager;
 import de.btobastian.javacord.utils.ThreadPool;
 import de.btobastian.javacord.utils.logging.LoggerUtil;
@@ -77,7 +77,7 @@ public class ImplDiscordApi implements DiscordApi {
     /**
      * The websocket adapter used to connect to Discord.
      */
-    private DiscordWebsocketAdapter websocketAdapter = null;
+    private DiscordWebSocketAdapter websocketAdapter = null;
 
     /**
      * The account type of the bot.
@@ -239,7 +239,7 @@ public class ImplDiscordApi implements DiscordApi {
                         return;
                     }
 
-                    websocketAdapter = new DiscordWebsocketAdapter(this, gateway);
+                    websocketAdapter = new DiscordWebSocketAdapter(this, gateway);
                     websocketAdapter.isReady().whenComplete((readyReceived, throwable) -> {
                         if (readyReceived) {
                             if (accountType == AccountType.BOT) {
@@ -592,7 +592,7 @@ public class ImplDiscordApi implements DiscordApi {
      *       so for the end user it is in fact never null.
      */
     @Override
-    public DiscordWebsocketAdapter getWebSocketAdapter() {
+    public DiscordWebSocketAdapter getWebSocketAdapter() {
         return websocketAdapter;
     }
 

--- a/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
+++ b/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
@@ -52,12 +52,12 @@ import java.util.zip.Inflater;
 /**
  * The main websocket adapter.
  */
-public class DiscordWebsocketAdapter extends WebSocketAdapter {
+public class DiscordWebSocketAdapter extends WebSocketAdapter {
 
     /**
      * The logger of this class.
      */
-    private static final Logger logger = LoggerUtil.getLogger(DiscordWebsocketAdapter.class);
+    private static final Logger logger = LoggerUtil.getLogger(DiscordWebSocketAdapter.class);
 
     private final DiscordApi api;
     private final HashMap<String, PacketHandler> handlers = new HashMap<>();
@@ -83,7 +83,7 @@ public class DiscordWebsocketAdapter extends WebSocketAdapter {
     // A reconnect attempt counter
     private int reconnectAttempt = 0;
 
-    public DiscordWebsocketAdapter(DiscordApi api, String gateway) {
+    public DiscordWebSocketAdapter(DiscordApi api, String gateway) {
         this.api = api;
         this.gateway = gateway;
 

--- a/src/main/java/de/btobastian/javacord/utils/PacketHandler.java
+++ b/src/main/java/de/btobastian/javacord/utils/PacketHandler.java
@@ -79,7 +79,7 @@ public abstract class PacketHandler {
      * @param listeners The listeners for the event.
      * @param consumer The consumer which consumes the listeners and calls the event.
      * @param <T> The listener class.
-     * @see DiscordWebsocketAdapter#dispatchEvent(List, Consumer)
+     * @see DiscordWebSocketAdapter#dispatchEvent(List, Consumer)
      */
     protected <T> void dispatchEvent(List<T> listeners, Consumer<T> consumer) {
         api.getWebSocketAdapter().dispatchEvent(listeners, consumer);


### PR DESCRIPTION
This is more consistent with official naming in the spec, with the namings in the used WS lib and even with other parts in Javacord like `getWebSocketAdapter()`