### PR TITLE
Used cached client id for the invite builder

### DIFF
--- a/src/main/java/de/btobastian/javacord/DiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/DiscordApi.java
@@ -101,8 +101,8 @@ public interface DiscordApi {
      *
      * @return An invite link for this bot.
      */
-    default CompletableFuture<String> createBotInvite() {
-        return getApplicationInfo().thenApply(info -> new BotInviteBuilder(info.getClientId()).build());
+    default String createBotInvite() {
+        return new BotInviteBuilder(getClientId()).build();
     }
 
     /**
@@ -112,9 +112,8 @@ public interface DiscordApi {
      * @param permissions The permissions which should be granted to the bot.
      * @return An invite link for this bot.
      */
-    default CompletableFuture<String> createBotInvite(Permissions permissions) {
-        return getApplicationInfo()
-                .thenApply(info -> new BotInviteBuilder(info.getClientId()).setPermissions(permissions).build());
+    default String createBotInvite(Permissions permissions) {
+        return new BotInviteBuilder(getClientId()).setPermissions(permissions).build();
     }
 
     /**
@@ -379,7 +378,7 @@ public interface DiscordApi {
      * @return The user with the given id.
      */
     Optional<User> getUserById(long id);
-    
+
     /**
      * Gets a user by it's id.
      *


### PR DESCRIPTION
As the client id is now retrieved at startup and cached, there is no need to re-request it again on invite building anymore which also removes the need to use a `CompletableFuture`