### PR TITLE
Added trace-level logging for OkHttpClient calls and WebSocket events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,11 @@
             <artifactId>okhttp</artifactId>
             <version>3.9.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>logging-interceptor</artifactId>
+            <version>3.9.1</version>
+        </dependency>
 
         <!-- The JSON-lib cause discord returns in json format -->
         <dependency>

--- a/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
@@ -87,6 +87,8 @@ import de.btobastian.javacord.utils.rest.RestEndpoint;
 import de.btobastian.javacord.utils.rest.RestMethod;
 import de.btobastian.javacord.utils.rest.RestRequest;
 import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
+import okhttp3.logging.HttpLoggingInterceptor.Level;
 import org.slf4j.Logger;
 
 import java.lang.ref.Reference;
@@ -343,6 +345,7 @@ public class ImplDiscordApi implements DiscordApi {
                         .newBuilder()
                         .addHeader("User-Agent", Javacord.USER_AGENT)
                         .build()))
+                .addInterceptor(new HttpLoggingInterceptor(LoggerUtil.getLogger(OkHttpClient.class)::trace).setLevel(Level.BODY))
                 .build();
 
         if (ready != null) {

--- a/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
+++ b/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
@@ -50,6 +50,7 @@ import de.btobastian.javacord.utils.handler.user.PresencesReplaceHandler;
 import de.btobastian.javacord.utils.handler.user.TypingStartHandler;
 import de.btobastian.javacord.utils.handler.user.UserUpdateHandler;
 import de.btobastian.javacord.utils.logging.LoggerUtil;
+import de.btobastian.javacord.utils.logging.WebSocketLogger;
 import de.btobastian.javacord.utils.rest.RestEndpoint;
 import de.btobastian.javacord.utils.rest.RestMethod;
 import de.btobastian.javacord.utils.rest.RestRequest;
@@ -233,6 +234,7 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
             this.websocket.set(websocket);
             websocket.addHeader("Accept-Encoding", "gzip");
             websocket.addListener(this);
+            websocket.addListener(new WebSocketLogger());
             waitForIdentifyRateLimit();
             websocket.connect();
         } catch (Throwable t) {

--- a/src/main/java/de/btobastian/javacord/utils/logging/WebSocketLogger.java
+++ b/src/main/java/de/btobastian/javacord/utils/logging/WebSocketLogger.java
@@ -1,0 +1,140 @@
+package de.btobastian.javacord.utils.logging;
+
+import java.util.List;
+import java.util.Map;
+
+import com.neovisionaries.ws.client.WebSocket;
+import com.neovisionaries.ws.client.WebSocketException;
+import com.neovisionaries.ws.client.WebSocketFrame;
+import com.neovisionaries.ws.client.WebSocketListener;
+import com.neovisionaries.ws.client.WebSocketState;
+import org.slf4j.Logger;
+
+public class WebSocketLogger implements WebSocketListener {
+    private static final Logger logger = LoggerUtil.getLogger(WebSocketLogger.class);
+
+    @Override
+    public void onStateChanged(WebSocket websocket, WebSocketState newState) {
+        logger.trace("onStateChanged: newState='{}'", newState);
+    }
+
+    @Override
+    public void onConnected(WebSocket websocket, Map<String, List<String>> headers) {
+        logger.trace("onConnected: headers='{}'", headers);
+    }
+
+    @Override
+    public void onConnectError(WebSocket websocket, WebSocketException cause) {
+        logger.trace("onConnectError", cause);
+    }
+
+    @Override
+    public void onDisconnected(WebSocket websocket, WebSocketFrame serverCloseFrame, WebSocketFrame clientCloseFrame, boolean closedByServer) {
+        logger.trace("onDisconnected: closedByServer='{}' serverCloseFrame='{}' clientCloseFrame='{}'", closedByServer, serverCloseFrame, clientCloseFrame);
+    }
+
+    @Override
+    public void onFrame(WebSocket websocket, WebSocketFrame frame) {
+        logger.trace("onFrame: frame='{}'", frame);
+    }
+
+    @Override
+    public void onContinuationFrame(WebSocket websocket, WebSocketFrame frame) {
+        logger.trace("onContinuationFrame: frame='{}'", frame);
+    }
+
+    @Override
+    public void onTextFrame(WebSocket websocket, WebSocketFrame frame) {
+        logger.trace("onTextFrame: frame='{}'", frame);
+    }
+
+    @Override
+    public void onBinaryFrame(WebSocket websocket, WebSocketFrame frame) {
+        logger.trace("onBinaryFrame: frame='{}'", frame);
+    }
+
+    @Override
+    public void onCloseFrame(WebSocket websocket, WebSocketFrame frame) {
+        logger.trace("onCloseFrame: frame='{}'", frame);
+    }
+
+    @Override
+    public void onPingFrame(WebSocket websocket, WebSocketFrame frame) {
+        logger.trace("onPingFrame: frame='{}'", frame);
+    }
+
+    @Override
+    public void onPongFrame(WebSocket websocket, WebSocketFrame frame) {
+        logger.trace("onPongFrame: frame='{}'", frame);
+    }
+
+    @Override
+    public void onTextMessage(WebSocket websocket, String text) {
+        logger.trace("onTextMessage: text='{}'", text);
+    }
+
+    @Override
+    public void onBinaryMessage(WebSocket websocket, byte[] binary) {
+        logger.trace("onBinaryMessage: binary='{}'", binary);
+    }
+
+    @Override
+    public void onSendingFrame(WebSocket websocket, WebSocketFrame frame) {
+        logger.trace("onSendingFrame: frame='{}'", frame);
+    }
+
+    @Override
+    public void onFrameSent(WebSocket websocket, WebSocketFrame frame) {
+        logger.trace("onFrameSent: frame='{}'", frame);
+    }
+
+    @Override
+    public void onFrameUnsent(WebSocket websocket, WebSocketFrame frame) {
+        logger.trace("onFrameUnsent: frame='{}'", frame);
+    }
+
+    @Override
+    public void onError(WebSocket websocket, WebSocketException cause) {
+        logger.trace("onError", cause);
+    }
+
+    @Override
+    public void onFrameError(WebSocket websocket, WebSocketException cause, WebSocketFrame frame) {
+        logger.trace("onFrameError: frame='{}'", frame, cause);
+    }
+
+    @Override
+    public void onMessageError(WebSocket websocket, WebSocketException cause, List<WebSocketFrame> frames) {
+        logger.trace("onMessageError: frames='{}'", frames, cause);
+    }
+
+    @Override
+    public void onMessageDecompressionError(WebSocket websocket, WebSocketException cause, byte[] compressed) {
+        logger.trace("onMessageDecompressionError: compressed='{}'", compressed, cause);
+    }
+
+    @Override
+    public void onTextMessageError(WebSocket websocket, WebSocketException cause, byte[] data) {
+        logger.trace("onTextMessageError: data='{}'", data, cause);
+    }
+
+    @Override
+    public void onSendError(WebSocket websocket, WebSocketException cause, WebSocketFrame frame) {
+        logger.trace("onSendError: frame='{}'", frame, cause);
+    }
+
+    @Override
+    public void onUnexpectedError(WebSocket websocket, WebSocketException cause) {
+        logger.trace("onUnexpectedError", cause);
+    }
+
+    @Override
+    public void handleCallbackError(WebSocket websocket, Throwable cause) {
+        logger.trace("handleCallbackError", cause);
+    }
+
+    @Override
+    public void onSendingHandshake(WebSocket websocket, String requestLine, List<String[]> headers) {
+        logger.trace("onSendingHandshake: requestLine='{}' headers='{}'", requestLine, headers);
+    }
+}


### PR DESCRIPTION
With the old http lib there already was logging of this kind included on debug level.
With this PR the OkHttpClient calls are logged on trace level.
The WebSocket events are also logged on trace level.
With this logging enabled it is much easier to see what is going on and diagnose deeper-level problems.