### PR TITLE
Make HTTP responses usable when retrieved from an exception

### DIFF
--- a/src/main/java/de/btobastian/javacord/exceptions/CannotMessageUserException.java
+++ b/src/main/java/de/btobastian/javacord/exceptions/CannotMessageUserException.java
@@ -1,6 +1,7 @@
 package de.btobastian.javacord.exceptions;
 
 import de.btobastian.javacord.utils.rest.RestRequest;
+import de.btobastian.javacord.utils.rest.RestRequestResult;
 import okhttp3.Response;
 
 /**
@@ -18,12 +19,12 @@ public class CannotMessageUserException extends MissingPermissionsException {
      *
      * @param origin The origin of the exception.
      * @param message The message of the exception.
-     * @param response The response which caused the exception.
      * @param request The request.
+     * @param restRequestResult The rest request result which caused the exception.
      */
     public CannotMessageUserException(
-            Exception origin, String message, Response response, RestRequest<?> request) {
-        super(origin, message, response, request);
+            Exception origin, String message, RestRequest<?> request, RestRequestResult restRequestResult) {
+        super(origin, message, request, restRequestResult);
     }
 
 }

--- a/src/main/java/de/btobastian/javacord/exceptions/DiscordException.java
+++ b/src/main/java/de/btobastian/javacord/exceptions/DiscordException.java
@@ -1,6 +1,7 @@
 package de.btobastian.javacord.exceptions;
 
 import de.btobastian.javacord.utils.rest.RestRequest;
+import de.btobastian.javacord.utils.rest.RestRequestResult;
 import okhttp3.Response;
 
 import java.util.Optional;
@@ -11,37 +12,27 @@ import java.util.Optional;
 public class DiscordException extends Exception {
 
     /**
-     * The response. May be <code>null</code> if the exception was thrown before sending a request.
-     */
-    private final Response response;
-
-    /**
      * The request. May be <code>null</code> if the exception was thrown before creating a request.
      */
     private final RestRequest<?> request;
+
+    /**
+     * The rest request result. May be <code>null</code> if the exception was thrown before sending a request.
+     */
+    private final RestRequestResult restRequestResult;
 
     /**
      * Creates a new instance of this class.
      *
      * @param origin The origin of the exception.
      * @param message The message of the exception.
-     * @param response The response which caused the exception.
      * @param request The request.
+     * @param restRequestResult The rest request result which caused the exception.
      */
-    public DiscordException(Exception origin, String message, Response response, RestRequest<?> request) {
+    public DiscordException(Exception origin, String message, RestRequest<?> request, RestRequestResult restRequestResult) {
         super(message, origin);
-        this.response = response;
         this.request = request;
-    }
-
-    /**
-     * Gets the response which caused the exception.
-     * May not be present if the exception was thrown before sending a request.
-     *
-     * @return The response which caused the exception.
-     */
-    public Optional<Response> getResponse() {
-        return Optional.ofNullable(response);
+        this.restRequestResult = restRequestResult;
     }
 
     /**
@@ -52,6 +43,16 @@ public class DiscordException extends Exception {
      */
     public Optional<RestRequest<?>> getRequest() {
         return Optional.ofNullable(request);
+    }
+
+    /**
+     * Gets the rest request result which caused the exception.
+     * May not be present if the exception was thrown before sending a request.
+     *
+     * @return The rest request result which caused the exception.
+     */
+    public Optional<RestRequestResult> getRestRequestResult() {
+        return Optional.ofNullable(restRequestResult);
     }
 
 }

--- a/src/main/java/de/btobastian/javacord/exceptions/DiscordException.java
+++ b/src/main/java/de/btobastian/javacord/exceptions/DiscordException.java
@@ -29,7 +29,8 @@ public class DiscordException extends Exception {
      * @param request The request.
      * @param restRequestResult The rest request result which caused the exception.
      */
-    public DiscordException(Exception origin, String message, RestRequest<?> request, RestRequestResult restRequestResult) {
+    public DiscordException(
+            Exception origin, String message, RestRequest<?> request, RestRequestResult restRequestResult) {
         super(message, origin);
         this.request = request;
         this.restRequestResult = restRequestResult;

--- a/src/main/java/de/btobastian/javacord/exceptions/MissingPermissionsException.java
+++ b/src/main/java/de/btobastian/javacord/exceptions/MissingPermissionsException.java
@@ -1,6 +1,7 @@
 package de.btobastian.javacord.exceptions;
 
 import de.btobastian.javacord.utils.rest.RestRequest;
+import de.btobastian.javacord.utils.rest.RestRequestResult;
 import okhttp3.Response;
 
 /**
@@ -13,12 +14,12 @@ public class MissingPermissionsException extends DiscordException {
      *
      * @param origin The origin of the exception.
      * @param message The message of the exception.
-     * @param response The response which caused the exception.
      * @param request The request.
+     * @param restRequestResult The rest request result which caused the exception.
      */
     public MissingPermissionsException(
-            Exception origin, String message, Response response, RestRequest<?> request) {
-        super(origin, message, response, request);
+            Exception origin, String message, RestRequest<?> request, RestRequestResult restRequestResult) {
+        super(origin, message, request, restRequestResult);
     }
 
 }

--- a/src/main/java/de/btobastian/javacord/exceptions/RatelimitException.java
+++ b/src/main/java/de/btobastian/javacord/exceptions/RatelimitException.java
@@ -16,8 +16,7 @@ public class RatelimitException extends DiscordException {
      * @param message The message of the exception.
      * @param request The request.
      */
-    public RatelimitException(
-            Exception origin, String message, RestRequest<?> request) {
+    public RatelimitException(Exception origin, String message, RestRequest<?> request) {
         super(origin, message, request, null);
     }
 

--- a/src/main/java/de/btobastian/javacord/exceptions/RatelimitException.java
+++ b/src/main/java/de/btobastian/javacord/exceptions/RatelimitException.java
@@ -1,6 +1,7 @@
 package de.btobastian.javacord.exceptions;
 
 import de.btobastian.javacord.utils.rest.RestRequest;
+import de.btobastian.javacord.utils.rest.RestRequestResult;
 import okhttp3.Response;
 
 /**
@@ -13,12 +14,11 @@ public class RatelimitException extends DiscordException {
      *
      * @param origin The origin of the exception.
      * @param message The message of the exception.
-     * @param response The response which caused the exception.
      * @param request The request.
      */
     public RatelimitException(
-            Exception origin, String message, Response response, RestRequest<?> request) {
-        super(origin, message, response, request);
+            Exception origin, String message, RestRequest<?> request) {
+        super(origin, message, request, null);
     }
 
 }

--- a/src/main/java/de/btobastian/javacord/utils/ratelimits/RatelimitManager.java
+++ b/src/main/java/de/btobastian/javacord/utils/ratelimits/RatelimitManager.java
@@ -86,7 +86,7 @@ public class RatelimitManager {
                     if (request.incrementRetryCounter()) {
                         request.getResult().completeExceptionally(
                                 new RatelimitException(request.getOrigin(),
-                                        "You have been ratelimited and ran out of retires!", null, request)
+                                        "You have been ratelimited and ran out of retires!", request)
                         );
                         queue.remove(request);
                         bucket.setHasActiveScheduler(false);
@@ -107,7 +107,7 @@ public class RatelimitManager {
                                 if (req.incrementRetryCounter()) {
                                     req.getResult().completeExceptionally(
                                             new RatelimitException(req.getOrigin(),
-                                                    "You have been ratelimited and ran out of retires!", null, req)
+                                                    "You have been ratelimited and ran out of retires!", req)
                                     );
                                     return true;
                                 }

--- a/src/main/java/de/btobastian/javacord/utils/rest/RestRequest.java
+++ b/src/main/java/de/btobastian/javacord/utils/rest/RestRequest.java
@@ -324,15 +324,17 @@ public class RestRequest<T> {
         logger.debug("Trying to send {} request to {}{}",
                 method.name(), endpoint.getFullUrl(urlParameters), body != null ? " with body " + body : "");
 
-        try(Response response = getApi().getHttpClient().newCall(requestBuilder.build()).execute()) {
+        try (Response response = getApi().getHttpClient().newCall(requestBuilder.build()).execute()) {
             RestRequestResult result = new RestRequestResult(this, response);
             logger.debug("Sent {} request to {} and received status code {} with{} body{}",
                     method.name(), endpoint.getFullUrl(urlParameters), response.code(),
-                    result.getBody().map(b -> "").orElse(" empty"), result.getStringBody().map(s -> " " + s).orElse(""));
+                    result.getBody().map(b -> "").orElse(" empty"),
+                    result.getStringBody().map(s -> " " + s).orElse(""));
             if (response.code() >= 300 || response.code() < 200) {
                 if (!result.getJsonBody().isNull() && result.getJsonBody().has("code")) {
                     int code = result.getJsonBody().get("code").asInt();
-                    String message = result.getJsonBody().has("message") ? result.getJsonBody().get("message").asText() : null;
+                    String message = result.getJsonBody().has("message") ?
+                            result.getJsonBody().get("message").asText() : null;
                     switch (code) {
                         case 50007:
                             throw new CannotMessageUserException(origin,

--- a/src/main/java/de/btobastian/javacord/utils/rest/RestRequest.java
+++ b/src/main/java/de/btobastian/javacord/utils/rest/RestRequest.java
@@ -324,38 +324,39 @@ public class RestRequest<T> {
         logger.debug("Trying to send {} request to {}{}",
                 method.name(), endpoint.getFullUrl(urlParameters), body != null ? " with body " + body : "");
 
-        Response response = getApi().getHttpClient().newCall(requestBuilder.build()).execute();
-        RestRequestResult result = new RestRequestResult(this, response);
-        logger.debug("Sent {} request to {} and received status code {} with{} body{}",
-                method.name(), endpoint.getFullUrl(urlParameters), response.code(),
-                result.getBody().map(b -> "").orElse(" empty"), result.getStringBody().map(s -> " " + s).orElse(""));
-        if (response.code() >= 300 || response.code() < 200) {
-            if (!result.getJsonBody().isNull() && result.getJsonBody().has("code")) {
-                int code = result.getJsonBody().get("code").asInt();
-                String message = result.getJsonBody().has("message") ? result.getJsonBody().get("message").asText() : null;
-                switch (code) {
-                    case 50007:
-                        throw new CannotMessageUserException(origin,
-                                message == null ? "Cannot send message to this user" : message, response, this);
+        try(Response response = getApi().getHttpClient().newCall(requestBuilder.build()).execute()) {
+            RestRequestResult result = new RestRequestResult(this, response);
+            logger.debug("Sent {} request to {} and received status code {} with{} body{}",
+                    method.name(), endpoint.getFullUrl(urlParameters), response.code(),
+                    result.getBody().map(b -> "").orElse(" empty"), result.getStringBody().map(s -> " " + s).orElse(""));
+            if (response.code() >= 300 || response.code() < 200) {
+                if (!result.getJsonBody().isNull() && result.getJsonBody().has("code")) {
+                    int code = result.getJsonBody().get("code").asInt();
+                    String message = result.getJsonBody().has("message") ? result.getJsonBody().get("message").asText() : null;
+                    switch (code) {
+                        case 50007:
+                            throw new CannotMessageUserException(origin,
+                                    message == null ? "Cannot send message to this user" : message, this, result);
+                    }
+                }
+                switch (response.code()) {
+                    case 429:
+                        // A 429 will be handled in the RatelimitManager class
+                        return result;
+                    case 403:
+                        throw new MissingPermissionsException(origin,
+                                "Received a " + response.code() + " response from Discord with"
+                                        + (result.getBody().isPresent() ? "" : " empty") + " body"
+                                        + result.getStringBody().map(s -> " " + s).orElse("") + "!", this, result);
+                    default:
+                        throw new DiscordException(origin,
+                                "Received a " + response.code() + " response from Discord with"
+                                        + (result.getBody().isPresent() ? "" : " empty") + " body"
+                                        + result.getStringBody().map(s -> " " + s).orElse("") + "!", this, result);
                 }
             }
-            switch (response.code()) {
-                case 429:
-                    // A 429 will be handled in the RatelimitManager class
-                    return result;
-                case 403:
-                    throw new MissingPermissionsException(origin,
-                            "Received a " + response.code() + " response from Discord with"
-                                    + (result.getBody().isPresent() ? "" : " empty") + " body"
-                                    + result.getStringBody().map(s -> " " + s).orElse("") + "!", response, this);
-                default:
-                    throw new DiscordException(origin,
-                            "Received a " + response.code() + " response from Discord with"
-                                    + (result.getBody().isPresent() ? "" : " empty") + " body"
-                                    + result.getStringBody().map(s -> " " + s).orElse("") + "!", response, this);
-            }
+            return result;
         }
-        return result;
     }
 
 }


### PR DESCRIPTION
OkHttp responses (or response bodies) should be closed to prevent memory leaks.
This is done already implicitly as always `new RestRequestResult(this, response)` is called which calls `response.body().string()` which in turn implicitly closes the response body and thus also the response.
This though also makes it impossible to read the body of the result again, e. g. in an exception handler that wants to react differently according to what discord sent back exactly.

With this PR the `AutoClosable` property of the response is used to ensure explicitly that all requests are properly closed.
Besides that, the custom exceptions that previously had an optional `Request` and an optional `Response`, now have an optional `RestRequestResult` instead of the `Response` where the body of the response can be retrieved as well as the response itself to be checked for other properties like status code and so on.