### PR TITLE
Fixed the exception handling in the ratelimit manager

### DIFF
--- a/src/main/java/de/btobastian/javacord/utils/ratelimits/RatelimitManager.java
+++ b/src/main/java/de/btobastian/javacord/utils/ratelimits/RatelimitManager.java
@@ -148,8 +148,6 @@ public class RatelimitManager {
                             bucket.setRateLimitRemaining(0);
                             bucket.setRateLimitResetTimestamp(currentTime + retryAfter);
                         } else {
-                            restRequest.getResult().complete(result);
-
                             String remaining = result.getResponse().header("X-RateLimit-Remaining", "1");
                             long reset = restRequest
                                     .getEndpoint()
@@ -165,6 +163,8 @@ public class RatelimitManager {
 
                             bucket.setRateLimitRemaining(Integer.parseInt(remaining));
                             bucket.setRateLimitResetTimestamp(reset);
+
+                            restRequest.getResult().complete(result);
                         }
                     } catch (Exception e) {
                         restRequest.getResult().completeExceptionally(e);


### PR DESCRIPTION
If an exception occured after the moved `complete` call, the `catch` block called `completeExceptionally`, but that call was ignored because the `CompletableFuture` was already completed before. For me this occurred e. g. when doing a non-ratelimited request like the `/gateway` call (**not** `/gateway/bot`) where no `X-RateLimit-Reset` header was set and thus a `NullPointerException` was thrown which then was simply ignored.