### PR TITLE
Fixed the ratelimit handling for non-ratelimited endpoints

### DIFF
--- a/src/main/java/de/btobastian/javacord/utils/ratelimits/RatelimitManager.java
+++ b/src/main/java/de/btobastian/javacord/utils/ratelimits/RatelimitManager.java
@@ -155,7 +155,7 @@ public class RatelimitManager {
                                     .getEndpoint()
                                     .getHardcodedRatelimit()
                                     .map(ratelimit -> currentTime + api.getTimeOffset() + ratelimit)
-                                    .orElseGet(() -> Long.parseLong(result.getResponse().header("X-RateLimit-Reset")) * 1000);
+                                    .orElseGet(() -> Long.parseLong(result.getResponse().header("X-RateLimit-Reset", "0")) * 1000);
                             String global = result.getResponse().header("X-RateLimit-Global");
 
                             if (global != null && global.equals("true")) {


### PR DESCRIPTION
At non-ratelimited endpoints like the `/gateway` one (**not** `/gateway/bot`), there are no ratelimiting headers set, but the ratelimit manager assumed that `X-RateLimit-Reset` is always set if no hard-coded ratelimit is set. Now `0` is used as default value so that there is never a delay or wait time.