### PR TITLE
Log an error that happens during invocation of callback methods

### DIFF
--- a/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
+++ b/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
@@ -616,6 +616,11 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
     }
 
     @Override
+    public void handleCallbackError(WebSocket websocket, Throwable cause) throws Exception {
+        logger.error("Websocket callback error!", cause);
+    }
+
+    @Override
     public void onUnexpectedError(WebSocket websocket, WebSocketException cause) throws Exception {
         logger.warn("Websocket onUnexpected error!", cause);
     }


### PR DESCRIPTION
If in any of the callbacks of the `DiscordWebSocketAdapter` a throwable occurs, it is simply swallowed, as those exceptions are only forwarded to the `handleCallbackError` method of the listener which has the failing callback. Now the method is overwritten and logs the error.