### PR TITLE
Improve Identify Ratelimit Handling

### DIFF
--- a/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
+++ b/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
@@ -352,7 +352,7 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
                     sendIdentify(websocket);
                 } else {
                     // Invalid session :(
-                    int zeroToFourSeconds = new Random().nextInt(4000);
+                    int zeroToFourSeconds = (int) (Math.random() * 4000);
                     logger.info("Could not resume session. Reconnecting in {}.{} seconds...",
                                 1 + zeroToFourSeconds / 1000,
                                 1 + zeroToFourSeconds / 100 % 10);

--- a/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
+++ b/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
@@ -59,10 +59,6 @@ import java.util.function.Consumer;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
 
-import static com.neovisionaries.ws.client.WebSocketFrame.createTextFrame;
-import static java.util.Collections.synchronizedList;
-import static java.util.Collections.synchronizedMap;
-
 /**
  * The main websocket adapter.
  */
@@ -94,8 +90,9 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
 
     private boolean reconnect = true;
 
-    private final AtomicMarkableReference<WebSocketFrame> lastSentFrameWasIdentify = new AtomicMarkableReference<>(null, false);
-    private final List<WebSocketListener> identifyFrameListeners = synchronizedList(new ArrayList<>());
+    private final AtomicMarkableReference<WebSocketFrame> lastSentFrameWasIdentify =
+            new AtomicMarkableReference<>(null, false);
+    private final List<WebSocketListener> identifyFrameListeners = Collections.synchronizedList(new ArrayList<>());
 
     private long lastGuildMembersChunkReceived = System.currentTimeMillis();
 
@@ -104,7 +101,7 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
     // A reconnect attempt counter
     private int reconnectAttempt = 0;
 
-    private static final Map<String, Long> lastIdentificationPerAccount = synchronizedMap(new HashMap<>());
+    private static final Map<String, Long> lastIdentificationPerAccount = Collections.synchronizedMap(new HashMap<>());
     private static final ConcurrentMap<String, Semaphore> connectionDelaySemaphorePerAccount = new ConcurrentHashMap<>();
 
     static {
@@ -474,7 +471,7 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
         while (!identifyFrameListeners.isEmpty()) {
             websocket.removeListener(identifyFrameListeners.remove(0));
         }
-        WebSocketFrame identifyFrame = createTextFrame(identifyPacket.toString());
+        WebSocketFrame identifyFrame = WebSocketFrame.createTextFrame(identifyPacket.toString());
         lastSentFrameWasIdentify.set(identifyFrame, false);
         WebSocketAdapter identifyFrameListener = new WebSocketAdapter() {
             @Override

--- a/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
+++ b/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
@@ -100,10 +100,12 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
     private static final ConcurrentMap<String, Semaphore> connectionDelaySemaphorePerAccount = new ConcurrentHashMap<>();
 
     static {
+        // This scheduler makes sure that the semaphores get released after a while if it failed in the listener
+        // for whatever reason. It's just a fail-safe.
         Executors.newSingleThreadScheduledExecutor().scheduleWithFixedDelay(() ->
             connectionDelaySemaphorePerAccount.forEach((token, semaphore) -> {
                 if ((semaphore.availablePermits() == 0) &&
-                        ((System.currentTimeMillis() - lastIdentificationPerAccount.get(token)) >= 15_000)) {
+                        ((System.currentTimeMillis() - lastIdentificationPerAccount.get(token)) >= 15000)) {
                     semaphore.release();
                 }
             }), 10, 10, TimeUnit.SECONDS);

--- a/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
+++ b/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
@@ -352,7 +352,11 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
                     sendIdentify(websocket);
                 } else {
                     // Invalid session :(
-                    logger.info("Could not resume session. Reconnecting now...");
+                    int zeroToFourSeconds = new Random().nextInt(4000);
+                    logger.info("Could not resume session. Reconnecting in {}.{} seconds...",
+                                1 + zeroToFourSeconds / 1000,
+                                1 + zeroToFourSeconds / 100 % 10);
+                    lastIdentificationPerAccount.put(api.getToken(), System.currentTimeMillis() - 4000 + zeroToFourSeconds);
                     sendIdentify(websocket);
                 }
                 break;


### PR DESCRIPTION
When hitting the once-every-five-seconds identify ratelimit, the API sends back an invalid session response like when trying to resume an invalid session.
Javacord did always log that resuming did fail and waited five seconds before retrying.
This is not too correct, because after the resuming failed you can immediately do the normal login instead and the log message is plainly wrong as a resume was not even tried.

Now it is remembered whether the last sent frame was an identify frame. If not and the session invalid response arrives immediately an identify is tried and the resume-failed message logged, if yes, the next identify call is delayed for 5.1 seconds and the log correctly complains about the hit identify ratelimit.

Furthermore it is now tried to actively prevent to hit that ratelimit by only starting a connection for the same token and thus account if the last identify frame was sent more than 5.1 seconds ago and otherwise this time is waited. This works as long as the identifies happen in the same JVM. If the identifies happen in different JVMs, e. g. for different shards, then of course it cannot be prevented and the handling mentioned above kicks in.