### PR TITLE
Auto Sharding

### DIFF
--- a/src/main/java/de/btobastian/javacord/DiscordApiBuilder.java
+++ b/src/main/java/de/btobastian/javacord/DiscordApiBuilder.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.IntPredicate;
 import java.util.stream.IntStream;
 
 import de.btobastian.javacord.utils.logging.LoggerUtil;
@@ -69,7 +70,19 @@ public class DiscordApiBuilder {
      * @return A collection of {@link CompletableFuture}s which contain the {@code DiscordApi}s for the shards.
      */
     public Collection<CompletableFuture<DiscordApi>> loginAllShards() {
-        return loginShards(IntStream.range(0, totalShards).toArray());
+        return loginShards(shard -> true);
+    }
+
+    /**
+     * Login shards adhering to the given predicate to the account with the given token.
+     * It is invalid to call {@link #setCurrentShard(int)} with
+     * anything but {@code 0} before calling this method.
+     *
+     * @param shardsCondition The predicate for identifying shards to connect, starting with {@code 0}!
+     * @return A collection of {@link CompletableFuture}s which contain the {@code DiscordApi}s for the shards.
+     */
+    public Collection<CompletableFuture<DiscordApi>> loginShards(IntPredicate shardsCondition) {
+        return loginShards(IntStream.range(0, totalShards).filter(shardsCondition).toArray());
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
+++ b/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
@@ -144,6 +144,11 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
         }
     }
 
+    /**
+     * Sets the gateway used to connect.
+     *
+     * @param gateway The gateway to set.
+     */
     public static void setGateway(String gateway) {
         gatewayWriteLock.lock();
         try {

--- a/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
+++ b/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
@@ -144,6 +144,15 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
         }
     }
 
+    public static void setGateway(String gateway) {
+        gatewayWriteLock.lock();
+        try {
+            DiscordWebSocketAdapter.gateway = gateway;
+        } finally {
+            gatewayWriteLock.unlock();
+        }
+    }
+
     /**
      * Disconnects from the websocket.
      */


### PR DESCRIPTION
With these commits the `DiscordApiBuilder` is now able to login multiple shards and even automatically request the amount of recommended shards from the Discord API.
With these changes you can do stuff like for example


```java
new DiscordApiBuilder()
        .setToken(botToken)
        .setTotalShards(6)
        .loginAllShards()
        // or
        //.loginShards(shard -> shard % 2 == 0)
        // or
        //.loginShards(0, 1)
        // or
        //.loginShards(IntStream.range(0, 4).toArray())
        .forEach(shard -> shard
                .thenAccept(this::handleReadyEvent)
                .exceptionally(Javacord::exceptionLogger)
        );
```

or


```java
new DiscordApiBuilder()
        .setToken(botToken)
        .setRecommendedTotalShards()
        .thenAccept(discordApiBuilder -> discordApiBuilder
                .loginAllShards()
                // or
                //.loginShards(shard -> shard % 2 == 0)
                // or
                //.loginShards(0, 1)
                // or
                //.loginShards(IntStream.range(0, 10).toArray())
                .forEach(shard -> shard
                        .thenAccept(this::handleReadyEvent)
                        .exceptionally(Javacord::exceptionLogger)
                ))
        .exceptionally(Javacord::exceptionLogger);
```