### PR TITLE
Retry connection on any Throwable, not only on specific ones

### DIFF
--- a/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
+++ b/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
@@ -233,8 +233,8 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
                 } catch (InterruptedException ignored) { }
             }
             websocket.connect();
-        } catch (IOException | WebSocketException e) {
-            logger.warn("An error occurred while connecting to websocket", e);
+        } catch (Throwable t) {
+            logger.warn("An error occurred while connecting to websocket", t);
             if (reconnect) {
                 reconnectAttempt++;
                 logger.info("Trying to reconnect/resume in {} seconds!", api.getReconnectDelay(reconnectAttempt));


### PR DESCRIPTION
I had a `CompletionException` thrown during reconnection which made the reconnection tries just stop and nothing happened anymore and nothing was logged.
This was due to the `connect()` call being done in a `Future` that catches throwable and only rethrows if you call `get()` on it which would contradict its asynchonous action.
Now not only `IOException` and `WebSocketException` are caught, but all `Throwable`s and reconnection is triggered.

If you don't like this for whatever reason, it might be an alternative to add a catch clause for `Throwable` and there feed it to the uncaught exception handler like in `Thread currentThread = Thread.currentThread(); currentThread.getUncaughtExceptionHandler().uncaughtException(currentThread, t);`, so that the throwable is at least somehow handled and not swallowed silently like currently.