### PR TITLE
Add discriminated name convenience methods and make discriminator of message author optional

### DIFF
--- a/src/main/java/de/btobastian/javacord/DiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/DiscordApi.java
@@ -450,6 +450,28 @@ public interface DiscordApi {
     }
 
     /**
+     * Gets a user by its discriminated name like e. g. {@code Bastian#8222}.
+     *
+     * @param discriminatedName The discriminated name of the user.
+     * @return The user with the given discriminated name.
+     */
+    default Optional<User> getUserByDiscriminatedName(String discriminatedName) {
+        String[] nameAndDiscriminator = discriminatedName.split("#", 2);
+        return getUserByNameAndDiscriminator(nameAndDiscriminator[0], nameAndDiscriminator[1]);
+    }
+
+    /**
+     * Gets a user by its name and discriminator.
+     *
+     * @param name The name of the user.
+     * @param discriminator The discriminator of the user.
+     * @return The user with the given name and discriminator.
+     */
+    default Optional<User> getUserByNameAndDiscriminator(String name, String discriminator) {
+        return getUsersByName(name).stream().filter(user -> user.getDiscriminator().equals(discriminator)).findAny();
+    }
+
+    /**
      * Gets a collection with all users with the given name.
      * This method is case sensitive!
      *

--- a/src/main/java/de/btobastian/javacord/entities/User.java
+++ b/src/main/java/de/btobastian/javacord/entities/User.java
@@ -132,6 +132,15 @@ public interface User extends DiscordEntity, Messageable, Mentionable {
     }
 
     /**
+     * Gets the discriminated name of the user, e. g. {@code Bastian#8222}.
+     *
+     * @return The discriminated name of the user.
+     */
+    default String getDiscriminatedName() {
+        return getName() + "#" + getDiscriminator();
+    }
+
+    /**
      * Changes the nickname of the user in the given server.
      *
      * @param server The server.

--- a/src/main/java/de/btobastian/javacord/entities/message/MessageAuthor.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/MessageAuthor.java
@@ -46,11 +46,21 @@ public interface MessageAuthor extends DiscordEntity {
     }
 
     /**
-     * Gets the discriminator of the author.
+     * If the author is a user, gets the discriminated name of the user, e. g. {@code Bastian#8222},
+     * otherwise just gets the name of the author.
      *
-     * @return The discriminator of the author.
+     * @return The discriminated name of the user or the name of the author.
      */
-    String getDiscriminator();
+    default String getDiscriminatedName() {
+        return getDiscriminator().map(discriminator -> getName() + "#" + discriminator).orElseGet(this::getName);
+    }
+
+    /**
+     * Gets the discriminator of the author if the author is a user.
+     *
+     * @return The discriminator of the author if the author is a user.
+     */
+    Optional<String> getDiscriminator();
 
     /**
      * Gets the avatar of the author.

--- a/src/main/java/de/btobastian/javacord/entities/message/impl/ImplMessageAuthor.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/impl/ImplMessageAuthor.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Optional;
 
 /**
  * The implementation of {@link MessageAuthor}.
@@ -70,8 +71,8 @@ public class ImplMessageAuthor implements MessageAuthor {
     }
 
     @Override
-    public String getDiscriminator() {
-        return discriminator;
+    public Optional<String> getDiscriminator() {
+        return isUser() ? Optional.of(discriminator) : Optional.empty();
     }
 
     @Override


### PR DESCRIPTION
- Add `DiscordApi#getUserByDiscriminatedName(String)`
- Add `DiscordApi#getUserByNameAndDiscriminator(String, String)`
- Add `User#getDiscriminatedName()`
- Change `MessageAuthor#getDiscriminator()` to return `Optional<String>` instead of `String`. A webhook will always have discriminator `0000` and that is only relevant for default avatar calculation. For all other uses like displaying the discriminated name, the discriminator should be left out, so the method now only returns the discriminator if the author is a user and an empty `Optional` otherwise