### PR TITLE
Fix permission override calculation regarding personal denial

### DIFF
--- a/src/main/java/de/btobastian/javacord/entities/channels/ServerChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/ServerChannel.java
@@ -175,6 +175,9 @@ public interface ServerChannel extends Channel {
         }
         for (PermissionType type : PermissionType.values()) {
             Permissions permissions = getOverwrittenPermissions(user);
+            if (permissions.getState(type) == PermissionState.DENIED) {
+                builder.setState(type, PermissionState.DENIED);
+            }
             if (permissions.getState(type) == PermissionState.ALLOWED) {
                 builder.setState(type, PermissionState.ALLOWED);
             }


### PR DESCRIPTION
When a permission was denied on personal level while it would have been granted otherwise, the permission override calculation routing did not correctly deny the permission. Personally denied permissions were not considered at all. Now they are properly taken into account.