### PR TITLE
Prevent connecting twice on commanded reconnect

### DIFF
--- a/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
+++ b/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
@@ -377,7 +377,6 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
             case 7:
                 logger.debug("Received op 7 packet. Reconnecting...");
                 websocket.sendClose(1000);
-                connect();
                 break;
             case 9:
                 if (lastSentFrameWasIdentify.isMarked()) {


### PR DESCRIPTION
If Discord tells us to reconnect with opcode 7 on the WebSocket, we send a close frame and call `connect` afterwards.
The close frame though causes `onDisconnected` being called which also does a reconnect.
So now the manual `connect` call is not done, but the `onDisconnected` automatically reconnects.