### PR TITLE
Do not confuse the heartbeat timers of different web sockets

### DIFF
--- a/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
+++ b/src/main/java/de/btobastian/javacord/utils/DiscordWebSocketAdapter.java
@@ -67,6 +67,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -103,7 +104,7 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
 
     private WebSocket websocket = null;
 
-    private Timer heartbeatTimer = null;
+    private final Map<WebSocket, Timer> heartbeatTimerByWebSocket = Collections.synchronizedMap(new WeakHashMap<>());
 
     private int lastSeq = -1;
     private String sessionId = null;
@@ -284,10 +285,10 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
         }
 
         // Reconnect
-        if (heartbeatTimer != null) {
-            heartbeatTimer.cancel();
-            heartbeatTimer = null;
-        }
+        heartbeatTimerByWebSocket.computeIfPresent(websocket, (key, timer) -> {
+            timer.cancel();
+            return null;
+        });
 
         if (reconnect) {
             reconnectAttempt++;
@@ -400,7 +401,7 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
             
                 JsonNode data = packet.get("d");
                 int heartbeatInterval = data.get("heartbeat_interval").asInt();
-                heartbeatTimer = startHeartbeat(websocket, heartbeatInterval);
+                heartbeatTimerByWebSocket.compute(websocket, (key, timer) -> startHeartbeat(key, heartbeatInterval));
 
                 if (sessionId == null) {
                     sendIdentify(websocket);


### PR DESCRIPTION
If one websocket gets discarded and a new one created, it happened to me that two websockets at the same time did try to access the heartbeat timer from different threads as each `WebSocket` instance has its own `ReadingThread` instance. The one then canceled the timer and `null`ed it, then the other got a `NullPointerException`.
Now the heartbeat timer is assigned to the web socket it heartbeats to to prevent this.