### PR TITLE
Close connection if a heartbeat package was not answered properly until the next hearbeat is due

### DIFF
--- a/src/main/java/de/btobastian/javacord/utils/WebSocketCloseReason.java
+++ b/src/main/java/de/btobastian/javacord/utils/WebSocketCloseReason.java
@@ -1,0 +1,59 @@
+package de.btobastian.javacord.utils;
+
+/**
+ * A enum with all different channel types.
+ */
+public enum WebSocketCloseReason {
+
+    DISCONNECT(1000),
+    HEARTBEAT_NOT_PROPERLY_ANSWERED(1001, "Heartbeat was not answered properly");
+
+    /**
+     * The close code.
+     */
+    private final int closeCode;
+
+    /**
+     * The close reason.
+     */
+    private final String closeReason;
+
+    /**
+     * Creates a new web socket close reason.
+     *
+     * @param closeCode The close code.
+     */
+    WebSocketCloseReason(int closeCode) {
+        this(closeCode, null);
+    }
+
+    /**
+     * Creates a new web socket close reason.
+     *
+     * @param closeCode The close code.
+     * @param closeReason The close reason.
+     */
+    WebSocketCloseReason(int closeCode, String closeReason) {
+        this.closeCode = closeCode;
+        this.closeReason = closeReason;
+    }
+
+    /**
+     * Gets the close code.
+     *
+     * @return The close code.
+     */
+    public int getCloseCode() {
+        return closeCode;
+    }
+
+    /**
+     * Gets the close reason.
+     *
+     * @return The close reason.
+     */
+    public String getCloseReason() {
+        return closeReason;
+    }
+
+}


### PR DESCRIPTION
Implements the API doc requirement `If a client does not receive a heartbeat ack between its attempts at sending heartbeats, it should immediately terminate the connection with a non-1000 close code, reconnect, and attempt to resume.`.