### PR TITLE
Improve message caching

### DIFF
--- a/src/main/java/de/btobastian/javacord/entities/message/Message.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/Message.java
@@ -17,7 +17,6 @@ import de.btobastian.javacord.entities.message.embed.EmbedBuilder;
 import de.btobastian.javacord.entities.message.emoji.CustomEmoji;
 import de.btobastian.javacord.entities.message.emoji.Emoji;
 import de.btobastian.javacord.entities.message.emoji.impl.ImplUnicodeEmoji;
-import de.btobastian.javacord.entities.message.impl.ImplMessage;
 import de.btobastian.javacord.entities.permissions.PermissionType;
 import de.btobastian.javacord.entities.permissions.Role;
 import de.btobastian.javacord.listeners.message.MessageDeleteListener;
@@ -56,10 +55,7 @@ public interface Message extends DiscordEntity, Comparable<Message> {
         return new RestRequest<Void>(api, RestMethod.DELETE, RestEndpoint.MESSAGE_DELETE)
                 .setUrlParameters(String.valueOf(channelId), String.valueOf(messageId))
                 .setRatelimitRetries(250)
-                .execute(result -> {
-                    api.getCachedMessageById(messageId).ifPresent(msg -> ((ImplMessage) msg).setDeleted(true));
-                    return null;
-                });
+                .execute(result -> null);
     }
 
     /**
@@ -484,24 +480,6 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @param cachedForever  Whether the message should be kept in cache forever or not.
      */
     void setCachedForever(boolean cachedForever);
-
-    /**
-     * Checks if the information of this message is still valid.
-     * If the message got removed from cache but you stored this objects somewhere it might have outdated content.
-     *
-     * @return Whether the information of this message is still valid or not.
-     */
-    default boolean isValid() {
-        return getApi().getCachedMessageById(getId()).orElse(null) == this;
-    }
-
-    /**
-     * Whether this message is deleted or not.
-     * Deleted messages might still be in the cache for not more than 60 seconds.
-     *
-     * @return Whether the message is deleted or not.
-     */
-    boolean isDeleted();
 
     /**
      * Gets a list with all reactions of the message.

--- a/src/main/java/de/btobastian/javacord/entities/message/impl/ImplMessage.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/impl/ImplMessage.java
@@ -69,21 +69,6 @@ public class ImplMessage implements Message {
     private boolean cacheForever = false;
 
     /**
-     * As soon as we receive a message delete event, we mark the message as deleted.
-     */
-    private boolean deleted = false;
-
-    /**
-     * Whether the message should be kept in cache or not.
-     */
-    private boolean keepCached = true;
-
-    /**
-     * We use the counter to make sure a message is cached for at least 2 minutes!
-     */
-    private byte keepCachedCounter = 0;
-
-    /**
      * A list with all embeds.
      */
     private List<Embed> embeds = new ArrayList<>();
@@ -172,29 +157,6 @@ public class ImplMessage implements Message {
     }
 
     /**
-     * Checks if the message should be kept in cache.
-     *
-     * @return Whether the message should be kept in cache or not.
-     */
-    public boolean keepCached() {
-        if (keepCachedCounter <= 5) {
-            // keepCached() is checked every 30 seconds.
-            // This makes sure, that messages are cached for at least 2 minutes!
-            keepCachedCounter++;
-        }
-        return keepCached || keepCachedCounter <= 5;
-    }
-
-    /**
-     * Sets if the message should be kept in cache.
-     *
-     * @param keepCached Whether the message should be kept in cache or not.
-     */
-    public void setKeepCached(boolean keepCached) {
-        this.keepCached = keepCached;
-    }
-
-    /**
      * Sets the content of the message.
      *
      * @param content The content to set.
@@ -219,15 +181,6 @@ public class ImplMessage implements Message {
      */
     public void setEmbeds(List<Embed> embeds) {
         this.embeds = embeds;
-    }
-
-    /**
-     * Sets the deleted flag of the message.
-     *
-     * @param deleted The deleted flag.
-     */
-    public void setDeleted(boolean deleted) {
-        this.deleted = deleted;
     }
 
     /**
@@ -325,11 +278,6 @@ public class ImplMessage implements Message {
             // Just make sure it's in the cache
             ((ImplMessageCache) channel.getMessageCache()).addMessage(this);
         }
-    }
-
-    @Override
-    public boolean isDeleted() {
-        return deleted;
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/events/message/MessageEditEvent.java
+++ b/src/main/java/de/btobastian/javacord/events/message/MessageEditEvent.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 /**
  * A message delete event.
  */
-public class MessageEditEvent extends OptionalMessageEvent {
+public class MessageEditEvent extends RequestableMessageEvent {
 
     /**
      * The new content of the message.

--- a/src/main/java/de/btobastian/javacord/events/message/OptionalMessageEvent.java
+++ b/src/main/java/de/btobastian/javacord/events/message/OptionalMessageEvent.java
@@ -5,7 +5,6 @@ import de.btobastian.javacord.entities.channels.TextChannel;
 import de.btobastian.javacord.entities.message.Message;
 
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * A message event where the message is NOT guaranteed to be in the cache.
@@ -36,20 +35,6 @@ public abstract class OptionalMessageEvent extends MessageEvent {
      */
     public Optional<Message> getMessage() {
         return Optional.ofNullable(message);
-    }
-
-    /**
-     * Requests a message from Discord, if it's not cached.
-     *
-     * @return The message either from the cache or directly from Discord.
-     * @see TextChannel#getMessageById(long)
-     */
-    public CompletableFuture<Message> requestMessage() {
-        Optional<Message> message = getMessage();
-        if (!message.isPresent()) {
-            return getChannel().getMessageById(getMessageId());
-        }
-        return CompletableFuture.completedFuture(this.message);
     }
 
 }

--- a/src/main/java/de/btobastian/javacord/events/message/RequestableMessageEvent.java
+++ b/src/main/java/de/btobastian/javacord/events/message/RequestableMessageEvent.java
@@ -1,0 +1,37 @@
+package de.btobastian.javacord.events.message;
+
+import java.util.concurrent.CompletableFuture;
+
+import de.btobastian.javacord.DiscordApi;
+import de.btobastian.javacord.entities.channels.TextChannel;
+import de.btobastian.javacord.entities.message.Message;
+
+/**
+ * A message event where the message is NOT guaranteed to be in the cache, but can be requested from Discord.
+ */
+public abstract class RequestableMessageEvent extends OptionalMessageEvent {
+
+    /**
+     * Creates a new requestable message event.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message.
+     * @param channel The text channel in which the message was sent.
+     */
+    public RequestableMessageEvent(DiscordApi api, long messageId, TextChannel channel) {
+        super(api, messageId, channel);
+    }
+
+    /**
+     * Requests a message from Discord, if it's not cached.
+     *
+     * @return The message either from the cache or directly from Discord.
+     * @see TextChannel#getMessageById(long)
+     */
+    public CompletableFuture<Message> requestMessage() {
+        return getMessage()
+                .map(CompletableFuture::completedFuture)
+                .orElseGet(() -> getChannel().getMessageById(getMessageId()));
+    }
+
+}

--- a/src/main/java/de/btobastian/javacord/events/message/reaction/ReactionEvent.java
+++ b/src/main/java/de/btobastian/javacord/events/message/reaction/ReactionEvent.java
@@ -2,12 +2,12 @@ package de.btobastian.javacord.events.message.reaction;
 
 import de.btobastian.javacord.DiscordApi;
 import de.btobastian.javacord.entities.channels.TextChannel;
-import de.btobastian.javacord.events.message.OptionalMessageEvent;
+import de.btobastian.javacord.events.message.RequestableMessageEvent;
 
 /**
  * A reaction event.
  */
-public abstract class ReactionEvent extends OptionalMessageEvent {
+public abstract class ReactionEvent extends RequestableMessageEvent {
 
     /**
      * Creates a new reaction event.

--- a/src/main/java/de/btobastian/javacord/utils/handler/message/MessageDeleteBulkHandler.java
+++ b/src/main/java/de/btobastian/javacord/utils/handler/message/MessageDeleteBulkHandler.java
@@ -3,10 +3,10 @@ package de.btobastian.javacord.utils.handler.message;
 import com.fasterxml.jackson.databind.JsonNode;
 import de.btobastian.javacord.DiscordApi;
 import de.btobastian.javacord.entities.channels.ServerTextChannel;
-import de.btobastian.javacord.entities.message.impl.ImplMessage;
 import de.btobastian.javacord.events.message.MessageDeleteEvent;
 import de.btobastian.javacord.listeners.message.MessageDeleteListener;
 import de.btobastian.javacord.utils.PacketHandler;
+import de.btobastian.javacord.utils.cache.ImplMessageCache;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,7 +36,8 @@ public class MessageDeleteBulkHandler extends PacketHandler {
 
                 List<MessageDeleteListener> listeners = new ArrayList<>();
                 api.getCachedMessageById(messageId)
-                        .ifPresent(message -> ((ImplMessage) message).setDeleted(true));
+                        .ifPresent(((ImplMessageCache) channel.getMessageCache())::removeMessage);
+                api.removeMessageFromCache(messageId);
                 listeners.addAll(api.getMessageDeleteListeners(messageId));
                 listeners.addAll(channel.getMessageDeleteListeners());
                 if (channel instanceof ServerTextChannel) {

--- a/src/main/java/de/btobastian/javacord/utils/handler/message/MessageDeleteHandler.java
+++ b/src/main/java/de/btobastian/javacord/utils/handler/message/MessageDeleteHandler.java
@@ -3,10 +3,10 @@ package de.btobastian.javacord.utils.handler.message;
 import com.fasterxml.jackson.databind.JsonNode;
 import de.btobastian.javacord.DiscordApi;
 import de.btobastian.javacord.entities.channels.ServerTextChannel;
-import de.btobastian.javacord.entities.message.impl.ImplMessage;
 import de.btobastian.javacord.events.message.MessageDeleteEvent;
 import de.btobastian.javacord.listeners.message.MessageDeleteListener;
 import de.btobastian.javacord.utils.PacketHandler;
+import de.btobastian.javacord.utils.cache.ImplMessageCache;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,7 +35,8 @@ public class MessageDeleteHandler extends PacketHandler {
 
             List<MessageDeleteListener> listeners = new ArrayList<>();
             api.getCachedMessageById(messageId)
-                    .ifPresent(message -> ((ImplMessage) message).setDeleted(true));
+                    .ifPresent(((ImplMessageCache) channel.getMessageCache())::removeMessage);
+            api.removeMessageFromCache(messageId);
             listeners.addAll(api.getMessageDeleteListeners(messageId));
             listeners.addAll(channel.getMessageDeleteListeners());
             if (channel instanceof ServerTextChannel) {


### PR DESCRIPTION
- remove deleted messages from the cache immediately
- use a map with weak keys for the messages in DiscordApi
- only process needed messages for cleanup of the messages cache in DiscordApi using a ReferenceQueue instead of looping through all messages
- remove Message#valid, Message#keepCached and Message#deleted
- do not keep messages in the cache for at least two minutes by tight coupling but just keep it in the cache until the garbage collector gets rid of it
  - it is very unlikely that the GC runs between the creation of the result message in sendMessage and the arrival of the MESSAGE_CREATE event, so the same message object should be returned there usually
  - if a message gets deleted it is a matter of luck whether the message is still in the cache when the delete event will be fired, but this is the same as currently and for bulk deletes it was quite unlikely before already as it just gets a list of IDs of messages that don't have to be in the cache at all anyway; if you would like to make the users able to get the deleted message in the delete event, then you would need to preserve a hard reference for some time for a deleted message and additionally before deleting a message or bulk-deleting messages you would need to first request those messages from the API to get them into the cache; even then it would be uncertain, because if some other user deletes a message, you have no chance to get hold of it if it wasn't in the cache already