### PR TITLE
Improve exception handling

### DIFF
--- a/src/main/java/de/btobastian/javacord/exceptions/BadRequestException.java
+++ b/src/main/java/de/btobastian/javacord/exceptions/BadRequestException.java
@@ -4,9 +4,9 @@ import de.btobastian.javacord.utils.rest.RestRequest;
 import de.btobastian.javacord.utils.rest.RestRequestResult;
 
 /**
- * When we are not allowed to perform an action (HTTP response code 403).
+ * When we sent a bad request (HTTP response code 400).
  */
-public class MissingPermissionsException extends DiscordException {
+public class BadRequestException extends DiscordException {
 
     /**
      * Creates a new instance of this class.
@@ -16,7 +16,7 @@ public class MissingPermissionsException extends DiscordException {
      * @param request The request.
      * @param restRequestResult The rest request result which caused the exception.
      */
-    public MissingPermissionsException(
+    public BadRequestException(
             Exception origin, String message, RestRequest<?> request, RestRequestResult restRequestResult) {
         super(origin, message, request, restRequestResult);
     }

--- a/src/main/java/de/btobastian/javacord/exceptions/CannotMessageUserException.java
+++ b/src/main/java/de/btobastian/javacord/exceptions/CannotMessageUserException.java
@@ -4,7 +4,7 @@ import de.btobastian.javacord.utils.rest.RestRequest;
 import de.btobastian.javacord.utils.rest.RestRequestResult;
 
 /**
- * When the bot cannot message a user.
+ * When the user of the connected account cannot message a user.
  * This might have several reasons, e.g.
  * <ul>
  *   <li>The user blocked you</li>

--- a/src/main/java/de/btobastian/javacord/exceptions/DiscordExceptionInstantiator.java
+++ b/src/main/java/de/btobastian/javacord/exceptions/DiscordExceptionInstantiator.java
@@ -1,0 +1,26 @@
+package de.btobastian.javacord.exceptions;
+
+import de.btobastian.javacord.utils.rest.RestRequest;
+import de.btobastian.javacord.utils.rest.RestRequestResult;
+
+/**
+ * Represents a function that accepts four arguments ({@code Exception}, {@code String}, {@code RestRequest<?>} and
+ * {@code RestRequestResult}) and produces a discord exception of type {@code T}.
+ *
+ * @param <T> The type of the discord exception that is produced.
+ */
+@FunctionalInterface
+public interface DiscordExceptionInstantiator<T extends DiscordException> {
+
+    /**
+     * Creates a new instance of the class {@code T}.
+     *
+     * @param origin The origin of the exception.
+     * @param message The message of the exception.
+     * @param request The request.
+     * @param restRequestResult The rest request result which caused the exception.
+     * @return The new instance.
+     */
+    T createInstance(Exception origin, String message, RestRequest<?> request, RestRequestResult restRequestResult);
+
+}

--- a/src/main/java/de/btobastian/javacord/exceptions/NotFoundException.java
+++ b/src/main/java/de/btobastian/javacord/exceptions/NotFoundException.java
@@ -4,9 +4,9 @@ import de.btobastian.javacord.utils.rest.RestRequest;
 import de.btobastian.javacord.utils.rest.RestRequestResult;
 
 /**
- * When we are not allowed to perform an action (HTTP response code 403).
+ * When something was not found (HTTP response code 404).
  */
-public class MissingPermissionsException extends DiscordException {
+public class NotFoundException extends BadRequestException {
 
     /**
      * Creates a new instance of this class.
@@ -16,7 +16,7 @@ public class MissingPermissionsException extends DiscordException {
      * @param request The request.
      * @param restRequestResult The rest request result which caused the exception.
      */
-    public MissingPermissionsException(
+    public NotFoundException(
             Exception origin, String message, RestRequest<?> request, RestRequestResult restRequestResult) {
         super(origin, message, request, restRequestResult);
     }

--- a/src/main/java/de/btobastian/javacord/exceptions/ReactionBlockedException.java
+++ b/src/main/java/de/btobastian/javacord/exceptions/ReactionBlockedException.java
@@ -4,10 +4,10 @@ import de.btobastian.javacord.utils.rest.RestRequest;
 import de.btobastian.javacord.utils.rest.RestRequestResult;
 
 /**
- * When we are not allowed to perform an action (HTTP response code 403).
+ * When the user of the connected account cannot add a reaction to a message a user has written.
+ * This might happen when the user blocked you.
  */
-public class MissingPermissionsException extends DiscordException {
-
+public class ReactionBlockedException extends MissingPermissionsException {
     /**
      * Creates a new instance of this class.
      *
@@ -16,7 +16,7 @@ public class MissingPermissionsException extends DiscordException {
      * @param request The request.
      * @param restRequestResult The rest request result which caused the exception.
      */
-    public MissingPermissionsException(
+    public ReactionBlockedException(
             Exception origin, String message, RestRequest<?> request, RestRequestResult restRequestResult) {
         super(origin, message, request, restRequestResult);
     }

--- a/src/main/java/de/btobastian/javacord/exceptions/UnknownEmojiException.java
+++ b/src/main/java/de/btobastian/javacord/exceptions/UnknownEmojiException.java
@@ -4,9 +4,9 @@ import de.btobastian.javacord.utils.rest.RestRequest;
 import de.btobastian.javacord.utils.rest.RestRequestResult;
 
 /**
- * When we are not allowed to perform an action (HTTP response code 403).
+ * When the emoji that was sent, for example as reaction, is not an emoji Discord knows about.
  */
-public class MissingPermissionsException extends DiscordException {
+public class UnknownEmojiException extends BadRequestException {
 
     /**
      * Creates a new instance of this class.
@@ -16,7 +16,7 @@ public class MissingPermissionsException extends DiscordException {
      * @param request The request.
      * @param restRequestResult The rest request result which caused the exception.
      */
-    public MissingPermissionsException(
+    public UnknownEmojiException(
             Exception origin, String message, RestRequest<?> request, RestRequestResult restRequestResult) {
         super(origin, message, request, restRequestResult);
     }

--- a/src/main/java/de/btobastian/javacord/exceptions/UnknownMessageException.java
+++ b/src/main/java/de/btobastian/javacord/exceptions/UnknownMessageException.java
@@ -4,9 +4,10 @@ import de.btobastian.javacord.utils.rest.RestRequest;
 import de.btobastian.javacord.utils.rest.RestRequestResult;
 
 /**
- * When we are not allowed to perform an action (HTTP response code 403).
+ * When the message that was referenced, for example for adding a reaction to, is not a message Discord knows about
+ * (anymore).
  */
-public class MissingPermissionsException extends DiscordException {
+public class UnknownMessageException extends NotFoundException {
 
     /**
      * Creates a new instance of this class.
@@ -16,7 +17,7 @@ public class MissingPermissionsException extends DiscordException {
      * @param request The request.
      * @param restRequestResult The rest request result which caused the exception.
      */
-    public MissingPermissionsException(
+    public UnknownMessageException(
             Exception origin, String message, RestRequest<?> request, RestRequestResult restRequestResult) {
         super(origin, message, request, restRequestResult);
     }

--- a/src/main/java/de/btobastian/javacord/utils/rest/RestRequestHttpResponseCode.java
+++ b/src/main/java/de/btobastian/javacord/utils/rest/RestRequestHttpResponseCode.java
@@ -1,0 +1,233 @@
+package de.btobastian.javacord.utils.rest;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import de.btobastian.javacord.exceptions.BadRequestException;
+import de.btobastian.javacord.exceptions.DiscordException;
+import de.btobastian.javacord.exceptions.DiscordExceptionInstantiator;
+import de.btobastian.javacord.exceptions.MissingPermissionsException;
+import de.btobastian.javacord.exceptions.NotFoundException;
+
+/**
+ * An enum with all rest request result codes as defined by
+ * <a href="https://discordapp.com/developers/docs/topics/response-codes#json-error-response">Discord</a>.
+ */
+public enum RestRequestHttpResponseCode {
+
+    /**
+     * The request completed successfully
+     */
+    OK(200, "The request completed successfully"),
+
+    /**
+     * The entity was created successfully
+     */
+    CREATED(201, "The entity was created successfully"),
+
+    /**
+     * The request completed successfully but returned no content
+     */
+    NO_CONTENT(204, "The request completed successfully but returned no content"),
+
+    /**
+     * The entity was not modified (no action was taken)
+     */
+    NOT_MODIFIED(304, "The entity was not modified (no action was taken)"),
+
+    /**
+     * The request was improperly formatted, or the server couldn't understand it
+     */
+    BAD_REQUEST(400, "The request was improperly formatted, or the server couldn't understand it",
+                BadRequestException::new, BadRequestException.class),
+
+    /**
+     * The Authorization header was missing or invalid
+     */
+    UNAUTHORIZED(401, "The Authorization header was missing or invalid"),
+
+    /**
+     * The Authorization token you passed did not have permission to the resource
+     */
+    FORBIDDEN(403, "The Authorization token you passed did not have permission to the resource",
+              MissingPermissionsException::new, MissingPermissionsException.class),
+
+    /**
+     * The resource at the location specified doesn't exist
+     */
+    NOT_FOUND(404, "The resource at the location specified doesn't exist",
+              NotFoundException::new, NotFoundException.class),
+
+    /**
+     * The HTTP method used is not valid for the location specified
+     */
+    METHOD_NOT_ALLOWED(405, "The HTTP method used is not valid for the location specified"),
+
+    /**
+     * You've made too many requests.
+     *
+     * @see <a href="https://discordapp.com/developers/docs/topics/rate-limits#rate-limits">Rate Limits</a>
+     */
+    TOO_MANY_REQUESTS(429, "You've made too many requests"),
+
+    /**
+     * There was not a gateway available to process your request. Wait a bit and retry
+     */
+    GATEWAY_UNAVAILABLE(502, "There was not a gateway available to process your request. Wait a bit and retry");
+
+    /**
+     * A map for retrieving the enum instances by code.
+     */
+    private static final Map<Integer, RestRequestHttpResponseCode> instanceByCode;
+
+    /**
+     * A map for retrieving the enum instances by exception class.
+     */
+    private static final Map<Class<? extends DiscordException>, RestRequestHttpResponseCode> instanceByExceptionClass;
+
+    /**
+     * The actual numeric result code.
+     */
+    private final int code;
+
+    /**
+     * The textual meaning.
+     */
+    private final String meaning;
+
+    /**
+     * The discord exception instantiator that produces instances to throw for this kind of result code.
+     */
+    private final DiscordExceptionInstantiator<?> discordExceptionInstantiator;
+
+    /**
+     * The discord exception class to throw for this kind of result code.
+     */
+    private final Class<? extends DiscordException> discordExceptionClass;
+
+    static {
+        instanceByCode = Collections.unmodifiableMap(
+                Arrays.stream(values())
+                        .collect(Collectors.toMap(RestRequestHttpResponseCode::getCode, Function.identity())));
+
+        instanceByExceptionClass = Collections.unmodifiableMap(
+                Arrays.stream(values())
+                        .filter(restRequestHttpResponseCode ->
+                                        restRequestHttpResponseCode.getDiscordExceptionClass().isPresent())
+                        .collect(Collectors.toMap(restRequestHttpResponseCode ->
+                                                          restRequestHttpResponseCode.getDiscordExceptionClass()
+                                                                  .orElseThrow(AssertionError::new),
+                                                  Function.identity())));
+    }
+
+    /**
+     * Creates a new rest request http response code.
+     *
+     * @param code The actual numeric response code.
+     * @param meaning The textual meaning.
+     */
+    RestRequestHttpResponseCode(int code, String meaning) {
+        this(code, meaning, null, null);
+    }
+
+    /**
+     * Creates a new rest request http response code.
+     *
+     * @param code The actual numeric response code.
+     * @param meaning The textual meaning.
+     * @param discordExceptionInstantiator The discord exception instantiator that produces
+     *                                     instances to throw for this kind of result code.
+     */
+    <T extends DiscordException> RestRequestHttpResponseCode(
+            int code, String meaning,
+            DiscordExceptionInstantiator<T> discordExceptionInstantiator, Class<T> discordExceptionClass) {
+        this.code = code;
+        this.meaning = meaning;
+        this.discordExceptionInstantiator = discordExceptionInstantiator;
+        this.discordExceptionClass = discordExceptionClass;
+
+        if ((discordExceptionInstantiator == null) && (discordExceptionClass != null)
+            || (discordExceptionInstantiator != null) && (discordExceptionClass == null)) {
+
+            throw new IllegalArgumentException("discordExceptionInstantiator and discordExceptionClass do not match");
+        }
+    }
+
+    /**
+     * Gets the rest request http response code by actual numeric response code.
+     *
+     * @param code The actual numeric response code.
+     * @return The rest request http response code with the actual numeric response code.
+     */
+    public static Optional<RestRequestHttpResponseCode> fromCode(int code) {
+        return Optional.ofNullable(instanceByCode.get(code));
+    }
+
+    /**
+     * Gets the rest request http response code by discord exception class.
+     * If no entry for the given class is found, the parents are checked until match is found or
+     * {@code DiscordException} is reached.
+     *
+     * @param discordExceptionClass The discord exception class.
+     * @return The rest request http response code with the discord exception class.
+     */
+    @SuppressWarnings("unchecked")
+    public static Optional<RestRequestHttpResponseCode> fromDiscordExceptionClass(
+            Class<? extends DiscordException> discordExceptionClass) {
+        Class<? extends DiscordException> clazz = discordExceptionClass;
+        while (instanceByExceptionClass.get(clazz) == null) {
+            if (clazz == DiscordException.class) {
+                return Optional.empty();
+            }
+            clazz = (Class<? extends DiscordException>) clazz.getSuperclass();
+        }
+        return Optional.of(instanceByExceptionClass.get(clazz));
+    }
+
+    /**
+     * Gets the actual numeric response code.
+     *
+     * @return The actual numeric response code.
+     */
+    public int getCode() {
+        return code;
+    }
+
+    /**
+     * Gets the textual meaning.
+     *
+     * @return The textual meaning.
+     */
+    public String getMeaning() {
+        return meaning;
+    }
+
+    /**
+     * Gets the discord exception to throw for this kind of result code.
+     *
+     * @param origin The origin of the exception.
+     * @param message The message of the exception.
+     * @param request The request.
+     * @param restRequestResult The rest request result which caused the exception.
+     * @return The discord exception to throw for this kind of result code.
+     */
+    public Optional<? extends DiscordException> getDiscordException(
+            Exception origin, String message, RestRequest<?> request, RestRequestResult restRequestResult) {
+        return Optional.ofNullable(discordExceptionInstantiator)
+                .map(instantiator -> instantiator.createInstance(origin, message, request, restRequestResult));
+    }
+
+    /**
+     * Gets the discord exception class to throw for this kind of result code.
+     *
+     * @return The discord exception class to throw for this kind of result code.
+     */
+    public Optional<? extends Class<? extends DiscordException>> getDiscordExceptionClass() {
+        return Optional.ofNullable(discordExceptionClass);
+    }
+
+}

--- a/src/main/java/de/btobastian/javacord/utils/rest/RestRequestResultErrorCode.java
+++ b/src/main/java/de/btobastian/javacord/utils/rest/RestRequestResultErrorCode.java
@@ -1,0 +1,167 @@
+package de.btobastian.javacord.utils.rest;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import de.btobastian.javacord.exceptions.CannotMessageUserException;
+import de.btobastian.javacord.exceptions.DiscordException;
+import de.btobastian.javacord.exceptions.DiscordExceptionInstantiator;
+import de.btobastian.javacord.exceptions.ReactionBlockedException;
+import de.btobastian.javacord.exceptions.UnknownEmojiException;
+import de.btobastian.javacord.exceptions.UnknownMessageException;
+
+/**
+ * An enum with all rest request result codes as defined by
+ * <a href="https://discordapp.com/developers/docs/topics/response-codes#json-error-response">Discord</a>.
+ */
+public enum RestRequestResultErrorCode {
+
+    UNKNOWN_ACCOUNT(10001, "Unknown account"),
+    UNKNOWN_APPLICATION(10002, "Unknown application"),
+    UNKNOWN_CHANNEL(10003, "Unknown channel"),
+    UNKNOWN_GUILD(10004, "Unknown guild"),
+    UNKNOWN_INTEGRATION(10005, "Unknown integration"),
+    UNKNOWN_INVITE(10006, "Unknown invite"),
+    UNKNOWN_MEMBER(10007, "Unknown member"),
+    UNKNOWN_MESSAGE(10008, "Unknown message", UnknownMessageException::new),
+    UNKNOWN_OVERWRITE(10009, "Unknown overwrite"),
+    UNKNOWN_PROVIDER(10010, "Unknown provider"),
+    UNKNOWN_ROLE(10011, "Unknown role"),
+    UNKNOWN_TOKEN(10012, "Unknown token"),
+    UNKNOWN_USER(10013, "Unknown user"),
+    UNKNOWN_EMOJI(10014, "Unknown Emoji", UnknownEmojiException::new),
+    BOTS_CANNOT_USE_THIS_ENDPOINT(20001, "Bots cannot use this endpoint"),
+    ONLY_BOTS_CAN_USE_THIS_ENDPOINT(20002, "Only bots can use this endpoint"),
+    MAXIMUM_NUMBER_OF_GUILDS_REACHED(30001, "Maximum number of guilds reached (100)"),
+    MAXIMUM_NUMBER_OF_FRIENDS_REACHED(30002, "Maximum number of friends reached (1000)"),
+    MAXIMUM_NUMBER_OF_PINS_REACHED(30003, "Maximum number of pins reached (50)"),
+    MAXIMUM_NUMBER_OF_GUILD_ROLES_REACHED(30005, "Maximum number of guild roles reached (250)"),
+    TOO_MANY_REACTIONS(30010, "Too many reactions"),
+    MAXIMUM_NUMBER_OF_GUILD_CHANNELS_REACHED(30013, "Maximum number of guild channels reached (500)"),
+    UNAUTHORIZED(40001, "Unauthorized"),
+    MISSING_ACCESS(50001, "Missing access"),
+    INVALID_ACCOUNT_TYPE(50002, "Invalid account type"),
+    CANNOT_EXECUTE_ACTION_ON_A_DM_CHANNEL(50003, "Cannot execute action on a DM channel"),
+    WIDGET_DISABLED(50004, "Widget Disabled"),
+    CANNOT_EDIT_A_MESSAGE_AUTHORED_BY_ANOTHER_USER(50005, "Cannot edit a message authored by another user"),
+    CANNOT_SEND_AN_EMPTY_MESSAGE(50006, "Cannot send an empty message"),
+    CANNOT_SEND_MESSAGES_TO_THIS_USER(50007, "Cannot send messages to this user", CannotMessageUserException::new),
+    CANNOT_SEND_MESSAGES_IN_A_VOICE_CHANNEL(50008, "Cannot send messages in a voice channel"),
+    CHANNEL_VERIFICATION_LEVEL_IS_TOO_HIGH(50009, "Channel verification level is too high"),
+    OAUTH2_APPLICATION_DOES_NOT_HAVE_A_BOT(50010, "OAuth2 application does not have a bot"),
+    OAUTH2_APPLICATION_LIMIT_REACHED(50011, "OAuth2 application limit reached"),
+    INVALID_OAUTH_STATE(50012, "Invalid OAuth state"),
+    MISSING_PERMISSIONS(50013, "Missing permissions"),
+    INVALID_AUTHENTICATION_TOKEN(50014, "Invalid authentication token"),
+    NOTE_IS_TOO_LONG(50015, "Note is too long"),
+    PROVIDED_TOO_FEW_OR_TOO_MANY_MESSAGES_TO_DELETE(
+            50016, "Provided too few or too many messages to delete. "
+                   + "Must provide at least 2 and fewer than 100 messages to delete."),
+    A_MESSAGE_CAN_ONLY_BE_PINNED_TO_THE_CHANNEL_IT_WAS_SENT_IN(
+            50019, "A message can only be pinned to the channel it was sent in"),
+    CANNOT_EXECUTE_ACTION_ON_A_SYSTEM_MESSAGE(50021, "Cannot execute action on a system message"),
+    A_MESSAGE_PROVIDED_WAS_TOO_OLD_TO_BULK_DELETE(50034, "A message provided was too old to bulk delete"),
+    INVALID_FORM_BODY(50035, "Invalid Form Body"),
+    AN_INVITE_WAS_ACCEPTED_TO_A_GUILD_THE_APPLICATIONS_BOT_IS_NOT_IN(
+            50036, "An invite was accepted to a guild the application's bot is not in"),
+    INVALID_API_VERSION(50041, "Invalid API version"),
+    REACTION_BLOCKED(90001, "Reaction blocked", ReactionBlockedException::new);
+
+    /**
+     * A map for retrieving the enum instances by code.
+     */
+    private static final Map<Integer, RestRequestResultErrorCode> instanceByCode;
+
+    /**
+     * The actual numeric result code.
+     */
+    private final int code;
+
+    /**
+     * The textual meaning.
+     */
+    private final String meaning;
+
+    /**
+     * The discord exception instantiator that produces instances to throw for this kind of result code.
+     */
+    private final DiscordExceptionInstantiator<?> discordExceptionInstantiator;
+
+    static {
+        instanceByCode = Collections.unmodifiableMap(
+                Arrays.stream(values())
+                        .collect(Collectors.toMap(RestRequestResultErrorCode::getCode, Function.identity())));
+    }
+
+    /**
+     * Creates a new rest request result error code.
+     *
+     * @param code The actual numeric close code.
+     * @param meaning The textual meaning.
+     */
+    RestRequestResultErrorCode(int code, String meaning) {
+        this(code, meaning, null);
+    }
+
+    /**
+     * Creates a new rest request result error code.
+     *
+     * @param code The actual numeric close code.
+     * @param meaning The textual meaning.
+     * @param discordExceptionInstantiator The discord exception instantiator that produces
+     *                                     instances to throw for this kind of result code.
+     */
+    RestRequestResultErrorCode(int code, String meaning, DiscordExceptionInstantiator<?> discordExceptionInstantiator) {
+        this.code = code;
+        this.meaning = meaning;
+        this.discordExceptionInstantiator = discordExceptionInstantiator;
+    }
+
+    /**
+     * Gets the rest request result error code by actual numeric result code.
+     *
+     * @param code The actual numeric close code.
+     * @return The web socket close code with the actual numeric result code.
+     */
+    public static Optional<RestRequestResultErrorCode> fromCode(int code) {
+        return Optional.ofNullable(instanceByCode.get(code));
+    }
+
+    /**
+     * Gets the actual numeric result code.
+     *
+     * @return The actual numeric result code.
+     */
+    public int getCode() {
+        return code;
+    }
+
+    /**
+     * Gets the textual meaning.
+     *
+     * @return The textual meaning.
+     */
+    public String getMeaning() {
+        return meaning;
+    }
+
+    /**
+     * Gets the discord exception to throw for this kind of result code.
+     *
+     * @param origin The origin of the exception.
+     * @param message The message of the exception.
+     * @param request The request.
+     * @param restRequestResult The rest request result which caused the exception.
+     * @return The discord exception to throw for this kind of result code.
+     */
+    public Optional<? extends DiscordException> getDiscordException(
+            Exception origin, String message, RestRequest<?> request, RestRequestResult restRequestResult) {
+        return Optional.ofNullable(discordExceptionInstantiator)
+                .map(instantiator -> instantiator.createInstance(origin, message, request, restRequestResult));
+    }
+
+}


### PR DESCRIPTION
- Add BadRequestException for HTTP response 400
- Add NotFoundException for HTTP response 404
- Add ReactionBlockedException for when you try to react on a message of a user that blocked you
- Add UnknownEmojiException for when you try to react with an emoji Discord doesn't know about
- Add UnknownMessageException for when you specify an unknown message
- Add RestRequestHttpResponseCode enum which defines all Discord-used HTTP response codes and the exception classes that should be used for them if different from the generic DiscordException
- Add RestRequestResultErrorCode enum which defines all Discord-defined error codes in JSON results and the exception classes that should be used for them if different from the ones specific to the HTTP code; they still have to be subclasses of the exception for the HTTP code
- Change RestRequest to create the exceptions dynamically according to the two new enums instead of hard-coding a switch-case with magic numbers

This makes adding and using new specific exception like mentioned in #rewrite_discussion for JSON error codes and HTTP result codes a breeze.