### PR TITLE
Cleanupable To Prevent Memory Leaks

### DIFF
--- a/src/main/java/de/btobastian/javacord/DiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/DiscordApi.java
@@ -72,6 +72,7 @@ import de.btobastian.javacord.listeners.user.UserChangeNameListener;
 import de.btobastian.javacord.listeners.user.UserChangeNicknameListener;
 import de.btobastian.javacord.listeners.user.UserChangeStatusListener;
 import de.btobastian.javacord.listeners.user.UserStartTypingListener;
+import de.btobastian.javacord.listeners.user.channel.PrivateChannelCreateListener;
 import de.btobastian.javacord.utils.DiscordWebSocketAdapter;
 import de.btobastian.javacord.utils.ListenerManager;
 import de.btobastian.javacord.utils.ThreadPool;
@@ -1454,6 +1455,21 @@ public interface DiscordApi {
      * @return A list with all registered server channel delete listeners.
      */
     List<ServerChannelDeleteListener> getServerChannelDeleteListeners();
+
+    /**
+     * Adds a listener, which listens to private channel creations.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<PrivateChannelCreateListener> addPrivateChannelCreateListener(PrivateChannelCreateListener listener);
+
+    /**
+     * Gets a list with all registered private channel create listeners.
+     *
+     * @return A list with all registered private channel create listeners.
+     */
+    List<PrivateChannelCreateListener> getPrivateChannelCreateListeners();
 
     /**
      * Adds a listener, which listens to message deletions.

--- a/src/main/java/de/btobastian/javacord/DiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/DiscordApi.java
@@ -29,6 +29,7 @@ import de.btobastian.javacord.entities.permissions.Role;
 import de.btobastian.javacord.listeners.connection.LostConnectionListener;
 import de.btobastian.javacord.listeners.connection.ReconnectListener;
 import de.btobastian.javacord.listeners.connection.ResumeListener;
+import de.btobastian.javacord.listeners.group.channel.GroupChannelChangeNameListener;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelCreateListener;
 import de.btobastian.javacord.listeners.message.MessageCreateListener;
 import de.btobastian.javacord.listeners.message.MessageDeleteListener;
@@ -1502,6 +1503,22 @@ public interface DiscordApi {
      * @return A list with all registered group channel create listeners.
      */
     List<GroupChannelCreateListener> getGroupChannelCreateListeners();
+
+    /**
+     * Adds a listener, which listens to group channel name changes.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<GroupChannelChangeNameListener> addGroupChannelChangeNameListener(
+            GroupChannelChangeNameListener listener);
+
+    /**
+     * Gets a list with all registered group channel change name listeners.
+     *
+     * @return A list with all registered group channel change name listeners.
+     */
+    List<GroupChannelChangeNameListener> getGroupChannelChangeNameListeners();
 
     /**
      * Adds a listener, which listens to message deletions.

--- a/src/main/java/de/btobastian/javacord/DiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/DiscordApi.java
@@ -31,6 +31,7 @@ import de.btobastian.javacord.listeners.connection.ReconnectListener;
 import de.btobastian.javacord.listeners.connection.ResumeListener;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelChangeNameListener;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelCreateListener;
+import de.btobastian.javacord.listeners.group.channel.GroupChannelDeleteListener;
 import de.btobastian.javacord.listeners.message.MessageCreateListener;
 import de.btobastian.javacord.listeners.message.MessageDeleteListener;
 import de.btobastian.javacord.listeners.message.MessageEditListener;
@@ -1519,6 +1520,21 @@ public interface DiscordApi {
      * @return A list with all registered group channel change name listeners.
      */
     List<GroupChannelChangeNameListener> getGroupChannelChangeNameListeners();
+
+    /**
+     * Adds a listener, which listens to group channel deletions.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<GroupChannelDeleteListener> addGroupChannelDeleteListener(GroupChannelDeleteListener listener);
+
+    /**
+     * Gets a list with all registered group channel delete listeners.
+     *
+     * @return A list with all registered group channel delete listeners.
+     */
+    List<GroupChannelDeleteListener> getGroupChannelDeleteListeners();
 
     /**
      * Adds a listener, which listens to message deletions.

--- a/src/main/java/de/btobastian/javacord/DiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/DiscordApi.java
@@ -29,6 +29,7 @@ import de.btobastian.javacord.entities.permissions.Role;
 import de.btobastian.javacord.listeners.connection.LostConnectionListener;
 import de.btobastian.javacord.listeners.connection.ReconnectListener;
 import de.btobastian.javacord.listeners.connection.ResumeListener;
+import de.btobastian.javacord.listeners.group.channel.GroupChannelCreateListener;
 import de.btobastian.javacord.listeners.message.MessageCreateListener;
 import de.btobastian.javacord.listeners.message.MessageDeleteListener;
 import de.btobastian.javacord.listeners.message.MessageEditListener;
@@ -1486,6 +1487,21 @@ public interface DiscordApi {
      * @return A list with all registered private channel delete listeners.
      */
     List<PrivateChannelDeleteListener> getPrivateChannelDeleteListeners();
+
+    /**
+     * Adds a listener, which listens to group channel creations.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<GroupChannelCreateListener> addGroupChannelCreateListener(GroupChannelCreateListener listener);
+
+    /**
+     * Gets a list with all registered group channel create listeners.
+     *
+     * @return A list with all registered group channel create listeners.
+     */
+    List<GroupChannelCreateListener> getGroupChannelCreateListeners();
 
     /**
      * Adds a listener, which listens to message deletions.

--- a/src/main/java/de/btobastian/javacord/DiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/DiscordApi.java
@@ -73,6 +73,7 @@ import de.btobastian.javacord.listeners.user.UserChangeNicknameListener;
 import de.btobastian.javacord.listeners.user.UserChangeStatusListener;
 import de.btobastian.javacord.listeners.user.UserStartTypingListener;
 import de.btobastian.javacord.listeners.user.channel.PrivateChannelCreateListener;
+import de.btobastian.javacord.listeners.user.channel.PrivateChannelDeleteListener;
 import de.btobastian.javacord.utils.DiscordWebSocketAdapter;
 import de.btobastian.javacord.utils.ListenerManager;
 import de.btobastian.javacord.utils.ThreadPool;
@@ -1470,6 +1471,21 @@ public interface DiscordApi {
      * @return A list with all registered private channel create listeners.
      */
     List<PrivateChannelCreateListener> getPrivateChannelCreateListeners();
+
+    /**
+     * Adds a listener, which listens to private channel deletions.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<PrivateChannelDeleteListener> addPrivateChannelDeleteListener(PrivateChannelDeleteListener listener);
+
+    /**
+     * Gets a list with all registered private channel delete listeners.
+     *
+     * @return A list with all registered private channel delete listeners.
+     */
+    List<PrivateChannelDeleteListener> getPrivateChannelDeleteListeners();
 
     /**
      * Adds a listener, which listens to message deletions.

--- a/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
@@ -21,6 +21,7 @@ import de.btobastian.javacord.entities.message.impl.ImplMessage;
 import de.btobastian.javacord.listeners.connection.LostConnectionListener;
 import de.btobastian.javacord.listeners.connection.ReconnectListener;
 import de.btobastian.javacord.listeners.connection.ResumeListener;
+import de.btobastian.javacord.listeners.group.channel.GroupChannelCreateListener;
 import de.btobastian.javacord.listeners.message.MessageCreateListener;
 import de.btobastian.javacord.listeners.message.MessageDeleteListener;
 import de.btobastian.javacord.listeners.message.MessageEditListener;
@@ -1053,6 +1054,17 @@ public class ImplDiscordApi implements DiscordApi {
     @Override
     public List<PrivateChannelDeleteListener> getPrivateChannelDeleteListeners() {
         return getListeners(PrivateChannelDeleteListener.class);
+    }
+
+    @Override
+    public ListenerManager<GroupChannelCreateListener> addGroupChannelCreateListener(
+            GroupChannelCreateListener listener) {
+        return addListener(GroupChannelCreateListener.class, listener);
+    }
+
+    @Override
+    public List<GroupChannelCreateListener> getGroupChannelCreateListeners() {
+        return getListeners(GroupChannelCreateListener.class);
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
@@ -21,6 +21,7 @@ import de.btobastian.javacord.entities.message.impl.ImplMessage;
 import de.btobastian.javacord.listeners.connection.LostConnectionListener;
 import de.btobastian.javacord.listeners.connection.ReconnectListener;
 import de.btobastian.javacord.listeners.connection.ResumeListener;
+import de.btobastian.javacord.listeners.group.channel.GroupChannelChangeNameListener;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelCreateListener;
 import de.btobastian.javacord.listeners.message.MessageCreateListener;
 import de.btobastian.javacord.listeners.message.MessageDeleteListener;
@@ -1065,6 +1066,18 @@ public class ImplDiscordApi implements DiscordApi {
     @Override
     public List<GroupChannelCreateListener> getGroupChannelCreateListeners() {
         return getListeners(GroupChannelCreateListener.class);
+    }
+
+    @Override
+    public ListenerManager<GroupChannelChangeNameListener> addGroupChannelChangeNameListener(
+            GroupChannelChangeNameListener listener) {
+        return addListener(GroupChannelChangeNameListener.class, listener);
+    }
+
+    @Override
+    public ListenerManager<GroupChannelDeleteListener> addGroupChannelDeleteListener(
+            GroupChannelDeleteListener listener) {
+        return addListener(GroupChannelDeleteListener.class, listener);
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
@@ -23,6 +23,7 @@ import de.btobastian.javacord.listeners.connection.ReconnectListener;
 import de.btobastian.javacord.listeners.connection.ResumeListener;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelChangeNameListener;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelCreateListener;
+import de.btobastian.javacord.listeners.group.channel.GroupChannelDeleteListener;
 import de.btobastian.javacord.listeners.message.MessageCreateListener;
 import de.btobastian.javacord.listeners.message.MessageDeleteListener;
 import de.btobastian.javacord.listeners.message.MessageEditListener;
@@ -438,6 +439,18 @@ public class ImplDiscordApi implements DiscordApi {
         if ((oldChannel != null) && (oldChannel != channel)) {
             ((Cleanupable) oldChannel).cleanup();
         }
+    }
+
+    /**
+     * Removes a group channel from the cache.
+     *
+     * @param channelId The id of the channel to remove.
+     */
+    public void removeGroupChannelFromCache(long channelId) {
+        groupChannels.computeIfPresent(channelId, (key, groupChannel) -> {
+            ((Cleanupable) groupChannel).cleanup();
+            return null;
+        });
     }
 
     /**
@@ -1078,6 +1091,16 @@ public class ImplDiscordApi implements DiscordApi {
     public ListenerManager<GroupChannelDeleteListener> addGroupChannelDeleteListener(
             GroupChannelDeleteListener listener) {
         return addListener(GroupChannelDeleteListener.class, listener);
+    }
+
+    @Override
+    public List<GroupChannelDeleteListener> getGroupChannelDeleteListeners() {
+        return getListeners(GroupChannelDeleteListener.class);
+    }
+
+    @Override
+    public List<GroupChannelChangeNameListener> getGroupChannelChangeNameListeners() {
+        return getListeners(GroupChannelChangeNameListener.class);
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
@@ -65,6 +65,7 @@ import de.btobastian.javacord.listeners.user.UserChangeNicknameListener;
 import de.btobastian.javacord.listeners.user.UserChangeStatusListener;
 import de.btobastian.javacord.listeners.user.UserStartTypingListener;
 import de.btobastian.javacord.listeners.user.channel.PrivateChannelCreateListener;
+import de.btobastian.javacord.listeners.user.channel.PrivateChannelDeleteListener;
 import de.btobastian.javacord.utils.Cleanupable;
 import de.btobastian.javacord.utils.DiscordWebSocketAdapter;
 import de.btobastian.javacord.utils.ListenerManager;
@@ -1041,6 +1042,17 @@ public class ImplDiscordApi implements DiscordApi {
     @Override
     public List<PrivateChannelCreateListener> getPrivateChannelCreateListeners() {
         return getListeners(PrivateChannelCreateListener.class);
+    }
+
+    @Override
+    public ListenerManager<PrivateChannelDeleteListener> addPrivateChannelDeleteListener(
+            PrivateChannelDeleteListener listener) {
+        return addListener(PrivateChannelDeleteListener.class, listener);
+    }
+
+    @Override
+    public List<PrivateChannelDeleteListener> getPrivateChannelDeleteListeners() {
+        return getListeners(PrivateChannelDeleteListener.class);
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
@@ -64,6 +64,7 @@ import de.btobastian.javacord.listeners.user.UserChangeNameListener;
 import de.btobastian.javacord.listeners.user.UserChangeNicknameListener;
 import de.btobastian.javacord.listeners.user.UserChangeStatusListener;
 import de.btobastian.javacord.listeners.user.UserStartTypingListener;
+import de.btobastian.javacord.listeners.user.channel.PrivateChannelCreateListener;
 import de.btobastian.javacord.utils.Cleanupable;
 import de.btobastian.javacord.utils.DiscordWebSocketAdapter;
 import de.btobastian.javacord.utils.ListenerManager;
@@ -1029,6 +1030,17 @@ public class ImplDiscordApi implements DiscordApi {
     @Override
     public List<ServerChannelDeleteListener> getServerChannelDeleteListeners() {
         return getListeners(ServerChannelDeleteListener.class);
+    }
+
+    @Override
+    public ListenerManager<PrivateChannelCreateListener> addPrivateChannelCreateListener(
+            PrivateChannelCreateListener listener) {
+        return addListener(PrivateChannelCreateListener.class, listener);
+    }
+
+    @Override
+    public List<PrivateChannelCreateListener> getPrivateChannelCreateListeners() {
+        return getListeners(PrivateChannelCreateListener.class);
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
@@ -877,6 +877,7 @@ public class ImplDiscordApi implements DiscordApi {
                     // shutdown thread pool if within one minute no disconnect event was dispatched
                     threadPool.getScheduler().schedule(threadPool::shutdown, 1, TimeUnit.MINUTES);
                 }
+                ratelimitManager.cleanup();
             }
             disconnectCalled = true;
         }

--- a/src/main/java/de/btobastian/javacord/entities/User.java
+++ b/src/main/java/de/btobastian/javacord/entities/User.java
@@ -22,6 +22,7 @@ import de.btobastian.javacord.listeners.user.UserChangeNameListener;
 import de.btobastian.javacord.listeners.user.UserChangeNicknameListener;
 import de.btobastian.javacord.listeners.user.UserChangeStatusListener;
 import de.btobastian.javacord.listeners.user.UserStartTypingListener;
+import de.btobastian.javacord.listeners.user.channel.PrivateChannelCreateListener;
 import de.btobastian.javacord.utils.ListenerManager;
 
 import java.util.Collection;
@@ -208,6 +209,27 @@ public interface User extends DiscordEntity, Messageable, Mentionable {
      * @return The new (or old) private channel with the user.
      */
     CompletableFuture<PrivateChannel> openPrivateChannel();
+
+    /**
+     * Adds a listener, which listens to private channel creations for this user.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<PrivateChannelCreateListener> addPrivateChannelCreateListener(
+            PrivateChannelCreateListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                User.class, getId(), PrivateChannelCreateListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered private channel create listeners.
+     *
+     * @return A list with all registered private channel create listeners.
+     */
+    default List<PrivateChannelCreateListener> getPrivateChannelCreateListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(User.class, getId(), PrivateChannelCreateListener.class);
+    }
 
     /**
      * Adds a listener, which listens to message creates from this user.

--- a/src/main/java/de/btobastian/javacord/entities/User.java
+++ b/src/main/java/de/btobastian/javacord/entities/User.java
@@ -6,6 +6,7 @@ import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entities.channels.PrivateChannel;
 import de.btobastian.javacord.entities.message.Messageable;
 import de.btobastian.javacord.entities.permissions.Role;
+import de.btobastian.javacord.listeners.group.channel.GroupChannelChangeNameListener;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelCreateListener;
 import de.btobastian.javacord.listeners.message.MessageCreateListener;
 import de.btobastian.javacord.listeners.message.reaction.ReactionAddListener;
@@ -273,6 +274,28 @@ public interface User extends DiscordEntity, Messageable, Mentionable {
      */
     default List<GroupChannelCreateListener> getGroupChannelCreateListeners() {
         return ((ImplDiscordApi) getApi()).getObjectListeners(User.class, getId(), GroupChannelCreateListener.class);
+    }
+
+    /**
+     * Adds a listener, which listens to group channel name changes for this user.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<GroupChannelChangeNameListener> addGroupChannelChangeNameListener(
+            GroupChannelChangeNameListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                User.class, getId(), GroupChannelChangeNameListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered group channel change name listeners.
+     *
+     * @return A list with all registered group channel change name listeners.
+     */
+    default List<GroupChannelChangeNameListener> getGroupChannelChangeNameListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                User.class, getId(), GroupChannelChangeNameListener.class);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/User.java
+++ b/src/main/java/de/btobastian/javacord/entities/User.java
@@ -23,6 +23,7 @@ import de.btobastian.javacord.listeners.user.UserChangeNicknameListener;
 import de.btobastian.javacord.listeners.user.UserChangeStatusListener;
 import de.btobastian.javacord.listeners.user.UserStartTypingListener;
 import de.btobastian.javacord.listeners.user.channel.PrivateChannelCreateListener;
+import de.btobastian.javacord.listeners.user.channel.PrivateChannelDeleteListener;
 import de.btobastian.javacord.utils.ListenerManager;
 
 import java.util.Collection;
@@ -229,6 +230,27 @@ public interface User extends DiscordEntity, Messageable, Mentionable {
      */
     default List<PrivateChannelCreateListener> getPrivateChannelCreateListeners() {
         return ((ImplDiscordApi) getApi()).getObjectListeners(User.class, getId(), PrivateChannelCreateListener.class);
+    }
+
+    /**
+     * Adds a listener, which listens to private channel deletions for this user.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<PrivateChannelDeleteListener> addPrivateChannelDeleteListener(
+            PrivateChannelDeleteListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                User.class, getId(), PrivateChannelDeleteListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered private channel delete listeners.
+     *
+     * @return A list with all registered private channel delete listeners.
+     */
+    default List<PrivateChannelDeleteListener> getPrivateChannelDeleteListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(User.class, getId(), PrivateChannelDeleteListener.class);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/User.java
+++ b/src/main/java/de/btobastian/javacord/entities/User.java
@@ -6,6 +6,7 @@ import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entities.channels.PrivateChannel;
 import de.btobastian.javacord.entities.message.Messageable;
 import de.btobastian.javacord.entities.permissions.Role;
+import de.btobastian.javacord.listeners.group.channel.GroupChannelCreateListener;
 import de.btobastian.javacord.listeners.message.MessageCreateListener;
 import de.btobastian.javacord.listeners.message.reaction.ReactionAddListener;
 import de.btobastian.javacord.listeners.message.reaction.ReactionRemoveListener;
@@ -251,6 +252,27 @@ public interface User extends DiscordEntity, Messageable, Mentionable {
      */
     default List<PrivateChannelDeleteListener> getPrivateChannelDeleteListeners() {
         return ((ImplDiscordApi) getApi()).getObjectListeners(User.class, getId(), PrivateChannelDeleteListener.class);
+    }
+
+    /**
+     * Adds a listener, which listens to group channel creations for this user.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<GroupChannelCreateListener> addGroupChannelCreateListener(
+            GroupChannelCreateListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                User.class, getId(), GroupChannelCreateListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered group channel create listeners.
+     *
+     * @return A list with all registered group channel create listeners.
+     */
+    default List<GroupChannelCreateListener> getGroupChannelCreateListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(User.class, getId(), GroupChannelCreateListener.class);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/User.java
+++ b/src/main/java/de/btobastian/javacord/entities/User.java
@@ -3,6 +3,7 @@ package de.btobastian.javacord.entities;
 import de.btobastian.javacord.AccountType;
 import de.btobastian.javacord.DiscordApi;
 import de.btobastian.javacord.ImplDiscordApi;
+import de.btobastian.javacord.entities.channels.GroupChannel;
 import de.btobastian.javacord.entities.channels.PrivateChannel;
 import de.btobastian.javacord.entities.message.Messageable;
 import de.btobastian.javacord.entities.permissions.Role;
@@ -213,6 +214,17 @@ public interface User extends DiscordEntity, Messageable, Mentionable {
      * @return The new (or old) private channel with the user.
      */
     CompletableFuture<PrivateChannel> openPrivateChannel();
+
+    /**
+     * Gets the currently existing group channels with the user.
+     *
+     * @return The group channels with the user.
+     */
+    default Collection<GroupChannel> getGroupChannels() {
+        return getApi().getGroupChannels().stream()
+                .filter(groupChannel -> groupChannel.getMembers().contains(this))
+                .collect(Collectors.toList());
+    }
 
     /**
      * Adds a listener, which listens to private channel creations for this user.

--- a/src/main/java/de/btobastian/javacord/entities/User.java
+++ b/src/main/java/de/btobastian/javacord/entities/User.java
@@ -8,6 +8,7 @@ import de.btobastian.javacord.entities.message.Messageable;
 import de.btobastian.javacord.entities.permissions.Role;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelChangeNameListener;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelCreateListener;
+import de.btobastian.javacord.listeners.group.channel.GroupChannelDeleteListener;
 import de.btobastian.javacord.listeners.message.MessageCreateListener;
 import de.btobastian.javacord.listeners.message.reaction.ReactionAddListener;
 import de.btobastian.javacord.listeners.message.reaction.ReactionRemoveListener;
@@ -296,6 +297,27 @@ public interface User extends DiscordEntity, Messageable, Mentionable {
     default List<GroupChannelChangeNameListener> getGroupChannelChangeNameListeners() {
         return ((ImplDiscordApi) getApi()).getObjectListeners(
                 User.class, getId(), GroupChannelChangeNameListener.class);
+    }
+
+    /**
+     * Adds a listener, which listens to group channel deletions for this user.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<GroupChannelDeleteListener> addGroupChannelDeleteListener(
+            GroupChannelDeleteListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                User.class, getId(), GroupChannelDeleteListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered group channel delete listeners.
+     *
+     * @return A list with all registered group channel delete listeners.
+     */
+    default List<GroupChannelDeleteListener> getGroupChannelDeleteListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(User.class, getId(), GroupChannelDeleteListener.class);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/channels/GroupChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/GroupChannel.java
@@ -4,6 +4,7 @@ import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entities.Icon;
 import de.btobastian.javacord.entities.User;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelChangeNameListener;
+import de.btobastian.javacord.listeners.group.channel.GroupChannelDeleteListener;
 import de.btobastian.javacord.utils.ListenerManager;
 
 import java.util.Collection;
@@ -94,6 +95,28 @@ public interface GroupChannel extends TextChannel, VoiceChannel {
     default List<GroupChannelChangeNameListener> getGroupChannelChangeNameListeners() {
         return ((ImplDiscordApi) getApi()).getObjectListeners(
                 GroupChannel.class, getId(), GroupChannelChangeNameListener.class);
+    }
+
+    /**
+     * Adds a listener, which listens to this channel being deleted.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<GroupChannelDeleteListener> addGroupChannelDeleteListener(
+            GroupChannelDeleteListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                GroupChannel.class, getId(), GroupChannelDeleteListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered group channel delete listeners.
+     *
+     * @return A list with all registered group channel delete listeners.
+     */
+    default List<GroupChannelDeleteListener> getGroupChannelDeleteListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                GroupChannel.class, getId(), GroupChannelDeleteListener.class);
     }
 
 }

--- a/src/main/java/de/btobastian/javacord/entities/channels/GroupChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/GroupChannel.java
@@ -1,9 +1,13 @@
 package de.btobastian.javacord.entities.channels;
 
+import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entities.Icon;
 import de.btobastian.javacord.entities.User;
+import de.btobastian.javacord.listeners.group.channel.GroupChannelChangeNameListener;
+import de.btobastian.javacord.utils.ListenerManager;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -68,6 +72,28 @@ public interface GroupChannel extends TextChannel, VoiceChannel {
      */
     default CompletableFuture<Void> updateName(String name) {
         return getUpdater().setName(name).update();
+    }
+
+    /**
+     * Adds a listener, which listens to this group channel name changes.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<GroupChannelChangeNameListener> addGroupChannelChangeNameListener(
+            GroupChannelChangeNameListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                GroupChannel.class, getId(), GroupChannelChangeNameListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered group channel change name listeners.
+     *
+     * @return A list with all registered group channel change name listeners.
+     */
+    default List<GroupChannelChangeNameListener> getGroupChannelChangeNameListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                GroupChannel.class, getId(), GroupChannelChangeNameListener.class);
     }
 
 }

--- a/src/main/java/de/btobastian/javacord/entities/channels/PrivateChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/PrivateChannel.java
@@ -1,6 +1,11 @@
 package de.btobastian.javacord.entities.channels;
 
+import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entities.User;
+import de.btobastian.javacord.listeners.user.channel.PrivateChannelDeleteListener;
+import de.btobastian.javacord.utils.ListenerManager;
+
+import java.util.List;
 
 /**
  * This class represents a private channel.
@@ -20,5 +25,27 @@ public interface PrivateChannel extends TextChannel, VoiceChannel {
      * @return The recipient of the private channel.
      */
     User getRecipient();
+
+    /**
+     * Adds a listener, which listens to this channel being deleted.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<PrivateChannelDeleteListener> addPrivateChannelDeleteListener(
+            PrivateChannelDeleteListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                PrivateChannel.class, getId(), PrivateChannelDeleteListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered private channel delete listeners.
+     *
+     * @return A list with all registered private channel delete listeners.
+     */
+    default List<PrivateChannelDeleteListener> getPrivateChannelDeleteListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                PrivateChannel.class, getId(), PrivateChannelDeleteListener.class);
+    }
 
 }

--- a/src/main/java/de/btobastian/javacord/entities/channels/impl/ImplGroupChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/impl/ImplGroupChannel.java
@@ -109,6 +109,15 @@ public class ImplGroupChannel implements GroupChannel, Cleanupable {
         return Optional.ofNullable(name);
     }
 
+    /**
+     * Sets the name of the channel.
+     *
+     * @param name The new name of the channel.
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
     @Override
     public Optional<Icon> getIcon() {
         if (iconId == null) {

--- a/src/main/java/de/btobastian/javacord/entities/channels/impl/ImplGroupChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/impl/ImplGroupChannel.java
@@ -7,6 +7,7 @@ import de.btobastian.javacord.entities.Icon;
 import de.btobastian.javacord.entities.User;
 import de.btobastian.javacord.entities.channels.GroupChannel;
 import de.btobastian.javacord.entities.impl.ImplIcon;
+import de.btobastian.javacord.utils.Cleanupable;
 import de.btobastian.javacord.utils.cache.ImplMessageCache;
 import de.btobastian.javacord.utils.cache.MessageCache;
 import de.btobastian.javacord.utils.logging.LoggerUtil;
@@ -23,7 +24,7 @@ import java.util.Optional;
 /**
  * The implementation of {@link GroupChannel}.
  */
-public class ImplGroupChannel implements GroupChannel {
+public class ImplGroupChannel implements GroupChannel, Cleanupable {
 
     /**
      * The logger of this class.
@@ -120,6 +121,11 @@ public class ImplGroupChannel implements GroupChannel {
             logger.warn("Seems like the url of the icon is malformed! Please contact the developer!", e);
             return Optional.empty();
         }
+    }
+
+    @Override
+    public void cleanup() {
+        messageCache.cleanup();
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/entities/channels/impl/ImplPrivateChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/impl/ImplPrivateChannel.java
@@ -6,13 +6,14 @@ import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entities.User;
 import de.btobastian.javacord.entities.channels.PrivateChannel;
 import de.btobastian.javacord.entities.impl.ImplUser;
+import de.btobastian.javacord.utils.Cleanupable;
 import de.btobastian.javacord.utils.cache.ImplMessageCache;
 import de.btobastian.javacord.utils.cache.MessageCache;
 
 /**
  * The implementation of {@link PrivateChannel}.
  */
-public class ImplPrivateChannel implements PrivateChannel {
+public class ImplPrivateChannel implements PrivateChannel, Cleanupable {
 
     /**
      * The discord api instance.
@@ -72,7 +73,13 @@ public class ImplPrivateChannel implements PrivateChannel {
 
 
     @Override
+    public void cleanup() {
+        messageCache.cleanup();
+    }
+
+    @Override
     public String toString() {
         return String.format("PrivateChannel (id: %s, recipient: %s)", getId(), getRecipient());
     }
+
 }

--- a/src/main/java/de/btobastian/javacord/entities/channels/impl/ImplServerTextChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/impl/ImplServerTextChannel.java
@@ -11,6 +11,7 @@ import de.btobastian.javacord.entities.impl.ImplServer;
 import de.btobastian.javacord.entities.permissions.Permissions;
 import de.btobastian.javacord.entities.permissions.Role;
 import de.btobastian.javacord.entities.permissions.impl.ImplPermissions;
+import de.btobastian.javacord.utils.Cleanupable;
 import de.btobastian.javacord.utils.cache.ImplMessageCache;
 import de.btobastian.javacord.utils.cache.MessageCache;
 
@@ -20,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * The implementation of {@link ServerTextChannel}.
  */
-public class ImplServerTextChannel implements ServerTextChannel {
+public class ImplServerTextChannel implements ServerTextChannel, Cleanupable {
 
     /**
      * The discord api instance.
@@ -220,6 +221,11 @@ public class ImplServerTextChannel implements ServerTextChannel {
     @Override
     public String getMentionTag() {
         return "<#" + getId() + ">";
+    }
+
+    @Override
+    public void cleanup() {
+        messageCache.cleanup();
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/entities/impl/ImplUser.java
+++ b/src/main/java/de/btobastian/javacord/entities/impl/ImplUser.java
@@ -12,6 +12,7 @@ import de.btobastian.javacord.entities.channels.PrivateChannel;
 import de.btobastian.javacord.entities.channels.impl.ImplPrivateChannel;
 import de.btobastian.javacord.entities.message.Message;
 import de.btobastian.javacord.entities.message.embed.EmbedBuilder;
+import de.btobastian.javacord.utils.Cleanupable;
 import de.btobastian.javacord.utils.logging.LoggerUtil;
 import de.btobastian.javacord.utils.rest.RestEndpoint;
 import de.btobastian.javacord.utils.rest.RestMethod;
@@ -27,7 +28,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * The implementation of {@link User}.
  */
-public class ImplUser implements User {
+public class ImplUser implements User, Cleanupable {
 
     /**
      * The logger of this class.
@@ -105,7 +106,12 @@ public class ImplUser implements User {
      * @param channel The channel to set.
      */
     public void setChannel(PrivateChannel channel) {
-        this.channel = channel;
+        if (this.channel != channel) {
+            if (this.channel != null) {
+                ((Cleanupable) this.channel).cleanup();
+            }
+            this.channel = channel;
+        }
     }
 
     /**
@@ -246,6 +252,13 @@ public class ImplUser implements User {
                 channel -> channel.sendMessage(content, embed, tts, nonce, stream, fileName).join(),
                 api.getThreadPool().getExecutorService()
         );
+    }
+
+    @Override
+    public void cleanup() {
+        if (channel != null) {
+            ((Cleanupable) channel).cleanup();
+        }
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/events/group/channel/GroupChannelChangeNameEvent.java
+++ b/src/main/java/de/btobastian/javacord/events/group/channel/GroupChannelChangeNameEvent.java
@@ -1,0 +1,50 @@
+package de.btobastian.javacord.events.group.channel;
+
+import de.btobastian.javacord.entities.channels.GroupChannel;
+
+/**
+ * A group channel change name event.
+ */
+public class GroupChannelChangeNameEvent extends GroupChannelEvent {
+
+    /**
+     * The new name of the channel.
+     */
+    private final String newName;
+
+    /**
+     * The old name of the channel.
+     */
+    private final String oldName;
+
+    /**
+     * Creates a new group channel change name event.
+     *
+     * @param channel The channel of the event.
+     * @param newName The new name of the channel.
+     * @param oldName The old name of the channel.
+     */
+    public GroupChannelChangeNameEvent(GroupChannel channel, String newName, String oldName) {
+        super(channel);
+        this.newName = newName;
+        this.oldName = oldName;
+    }
+
+    /**
+     * Gets the new name of the channel.
+     *
+     * @return The new name of the channel.
+     */
+    public String getNewName() {
+        return newName;
+    }
+
+    /**
+     * Gets the old name of the channel.
+     *
+     * @return The old name of the channel.
+     */
+    public String getOldName() {
+        return oldName;
+    }
+}

--- a/src/main/java/de/btobastian/javacord/events/group/channel/GroupChannelCreateEvent.java
+++ b/src/main/java/de/btobastian/javacord/events/group/channel/GroupChannelCreateEvent.java
@@ -1,0 +1,19 @@
+package de.btobastian.javacord.events.group.channel;
+
+import de.btobastian.javacord.entities.channels.GroupChannel;
+
+/**
+ * A group channel create event.
+ */
+public class GroupChannelCreateEvent extends GroupChannelEvent {
+
+    /**
+     * Creates a new group channel create event.
+     *
+     * @param channel The channel of the event.
+     */
+    public GroupChannelCreateEvent(GroupChannel channel) {
+        super(channel);
+    }
+
+}

--- a/src/main/java/de/btobastian/javacord/events/group/channel/GroupChannelDeleteEvent.java
+++ b/src/main/java/de/btobastian/javacord/events/group/channel/GroupChannelDeleteEvent.java
@@ -1,0 +1,19 @@
+package de.btobastian.javacord.events.group.channel;
+
+import de.btobastian.javacord.entities.channels.GroupChannel;
+
+/**
+ * A group channel delete event.
+ */
+public class GroupChannelDeleteEvent extends GroupChannelEvent {
+
+    /**
+     * Creates a new group channel delete event.
+     *
+     * @param channel The channel of the event.
+     */
+    public GroupChannelDeleteEvent(GroupChannel channel) {
+        super(channel);
+    }
+
+}

--- a/src/main/java/de/btobastian/javacord/events/group/channel/GroupChannelEvent.java
+++ b/src/main/java/de/btobastian/javacord/events/group/channel/GroupChannelEvent.java
@@ -1,0 +1,35 @@
+package de.btobastian.javacord.events.group.channel;
+
+import de.btobastian.javacord.entities.channels.GroupChannel;
+import de.btobastian.javacord.events.Event;
+
+/**
+ * A group channel event.
+ */
+public abstract class GroupChannelEvent extends Event {
+
+    /**
+     * The channel of the event.
+     */
+    private final GroupChannel channel;
+
+    /**
+     * Creates a new group channel event.
+     *
+     * @param channel The channel of the event.
+     */
+    public GroupChannelEvent(GroupChannel channel) {
+        super(channel.getApi());
+        this.channel = channel;
+    }
+
+    /**
+     * Gets the channel of the event.
+     *
+     * @return The channel of the event.
+     */
+    public GroupChannel getChannel() {
+        return channel;
+    }
+
+}

--- a/src/main/java/de/btobastian/javacord/events/user/channel/PrivateChannelCreateEvent.java
+++ b/src/main/java/de/btobastian/javacord/events/user/channel/PrivateChannelCreateEvent.java
@@ -1,0 +1,19 @@
+package de.btobastian.javacord.events.user.channel;
+
+import de.btobastian.javacord.entities.channels.PrivateChannel;
+
+/**
+ * A private channel create event.
+ */
+public class PrivateChannelCreateEvent extends PrivateChannelEvent {
+
+    /**
+     * Creates a new private channel create event.
+     *
+     * @param channel The channel of the event.
+     */
+    public PrivateChannelCreateEvent(PrivateChannel channel) {
+        super(channel);
+    }
+
+}

--- a/src/main/java/de/btobastian/javacord/events/user/channel/PrivateChannelDeleteEvent.java
+++ b/src/main/java/de/btobastian/javacord/events/user/channel/PrivateChannelDeleteEvent.java
@@ -1,0 +1,19 @@
+package de.btobastian.javacord.events.user.channel;
+
+import de.btobastian.javacord.entities.channels.PrivateChannel;
+
+/**
+ * A private channel delete event.
+ */
+public class PrivateChannelDeleteEvent extends PrivateChannelEvent {
+
+    /**
+     * Creates a new private channel delete event.
+     *
+     * @param channel The channel of the event.
+     */
+    public PrivateChannelDeleteEvent(PrivateChannel channel) {
+        super(channel);
+    }
+
+}

--- a/src/main/java/de/btobastian/javacord/events/user/channel/PrivateChannelEvent.java
+++ b/src/main/java/de/btobastian/javacord/events/user/channel/PrivateChannelEvent.java
@@ -1,0 +1,35 @@
+package de.btobastian.javacord.events.user.channel;
+
+import de.btobastian.javacord.entities.channels.PrivateChannel;
+import de.btobastian.javacord.events.user.UserEvent;
+
+/**
+ * A private channel event.
+ */
+public abstract class PrivateChannelEvent extends UserEvent {
+
+    /**
+     * The channel of the event.
+     */
+    private final PrivateChannel channel;
+
+    /**
+     * Creates a new private channel event.
+     *
+     * @param channel The channel of the event.
+     */
+    public PrivateChannelEvent(PrivateChannel channel) {
+        super(channel.getApi(), channel.getRecipient());
+        this.channel = channel;
+    }
+
+    /**
+     * Gets the channel of the event.
+     *
+     * @return The channel of the event.
+     */
+    public PrivateChannel getChannel() {
+        return channel;
+    }
+
+}

--- a/src/main/java/de/btobastian/javacord/listeners/group/channel/GroupChannelChangeNameListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/group/channel/GroupChannelChangeNameListener.java
@@ -1,0 +1,17 @@
+package de.btobastian.javacord.listeners.group.channel;
+
+import de.btobastian.javacord.events.group.channel.GroupChannelChangeNameEvent;
+
+/**
+ * This listener listens to group channel name changes.
+ */
+@FunctionalInterface
+public interface GroupChannelChangeNameListener {
+
+    /**
+     * This method is called every time a group channel's name changes.
+     *
+     * @param event The event.
+     */
+    void onGroupChannelChangeName(GroupChannelChangeNameEvent event);
+}

--- a/src/main/java/de/btobastian/javacord/listeners/group/channel/GroupChannelCreateListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/group/channel/GroupChannelCreateListener.java
@@ -1,0 +1,17 @@
+package de.btobastian.javacord.listeners.group.channel;
+
+import de.btobastian.javacord.events.group.channel.GroupChannelCreateEvent;
+
+/**
+ * This listener listens to group channel creations.
+ */
+@FunctionalInterface
+public interface GroupChannelCreateListener {
+
+    /**
+     * This method is called every time a group channel is created.
+     *
+     * @param event The event.
+     */
+    void onGroupChannelCreate(GroupChannelCreateEvent event);
+}

--- a/src/main/java/de/btobastian/javacord/listeners/group/channel/GroupChannelDeleteListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/group/channel/GroupChannelDeleteListener.java
@@ -1,0 +1,18 @@
+package de.btobastian.javacord.listeners.group.channel;
+
+import de.btobastian.javacord.events.group.channel.GroupChannelDeleteEvent;
+
+/**
+ * This listener listens to group channel deletions.
+ */
+@FunctionalInterface
+public interface GroupChannelDeleteListener {
+
+    /**
+     * This method is called every time a group channel is deleted.
+     *
+     * @param event The event.
+     */
+    void onGroupChannelDelete(GroupChannelDeleteEvent event);
+
+}

--- a/src/main/java/de/btobastian/javacord/listeners/user/channel/PrivateChannelCreateListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/user/channel/PrivateChannelCreateListener.java
@@ -1,0 +1,17 @@
+package de.btobastian.javacord.listeners.user.channel;
+
+import de.btobastian.javacord.events.user.channel.PrivateChannelCreateEvent;
+
+/**
+ * This listener listens to private channel creations.
+ */
+@FunctionalInterface
+public interface PrivateChannelCreateListener {
+
+    /**
+     * This method is called every time a private channel is created.
+     *
+     * @param event The event.
+     */
+    void onPrivateChannelCreate(PrivateChannelCreateEvent event);
+}

--- a/src/main/java/de/btobastian/javacord/listeners/user/channel/PrivateChannelDeleteListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/user/channel/PrivateChannelDeleteListener.java
@@ -1,0 +1,18 @@
+package de.btobastian.javacord.listeners.user.channel;
+
+import de.btobastian.javacord.events.user.channel.PrivateChannelDeleteEvent;
+
+/**
+ * This listener listens to private channel deletions.
+ */
+@FunctionalInterface
+public interface PrivateChannelDeleteListener {
+
+    /**
+     * This method is called every time a private channel is deleted.
+     *
+     * @param event The event.
+     */
+    void onPrivateChannelDelete(PrivateChannelDeleteEvent event);
+
+}

--- a/src/main/java/de/btobastian/javacord/utils/Cleanupable.java
+++ b/src/main/java/de/btobastian/javacord/utils/Cleanupable.java
@@ -1,0 +1,24 @@
+package de.btobastian.javacord.utils;
+
+import de.btobastian.javacord.DiscordApi;
+
+/**
+ * This class represents an object which can clean up after itself.
+ * It should be used on objects that need to clean up references to itself that would prevent garbage collection or when
+ * it "owns" cleanupable objects.
+ * The most prominent example is, when the {@link DiscordApi#getThreadPool() thread pool} is used to schedule a
+ * permanently repeated action on the object. This will prevent garbage collection as the scheduled task will have a
+ * hard reference to the instance and even if this is wrapped in a {@code WeakReference}, if a lambda is used as task,
+ * then the lambda has an implicit hard reference to the object. Thus the scheduled task should be cancelled in the
+ * {@link #cleanup()} method which should then be called by the owning object accordingly.
+ */
+public interface Cleanupable {
+
+    /**
+     * Does any cleanup that would prevent this instance from being eligible for garbage collection like cancelling
+     * scheduled repeated tasks or calling {@code cleanup} on "owned" cleanupable objects.
+     * This method has to be thread-safe and idempotent.
+     */
+    void cleanup();
+
+}

--- a/src/main/java/de/btobastian/javacord/utils/handler/channel/ChannelDeleteHandler.java
+++ b/src/main/java/de/btobastian/javacord/utils/handler/channel/ChannelDeleteHandler.java
@@ -2,11 +2,14 @@ package de.btobastian.javacord.utils.handler.channel;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import de.btobastian.javacord.DiscordApi;
+import de.btobastian.javacord.entities.User;
 import de.btobastian.javacord.entities.channels.ServerChannel;
 import de.btobastian.javacord.entities.impl.ImplServer;
 import de.btobastian.javacord.entities.impl.ImplUser;
+import de.btobastian.javacord.events.group.channel.GroupChannelDeleteEvent;
 import de.btobastian.javacord.events.server.channel.ServerChannelDeleteEvent;
 import de.btobastian.javacord.events.user.channel.PrivateChannelDeleteEvent;
+import de.btobastian.javacord.listeners.group.channel.GroupChannelDeleteListener;
 import de.btobastian.javacord.listeners.server.channel.ServerChannelDeleteListener;
 import de.btobastian.javacord.listeners.user.channel.PrivateChannelDeleteListener;
 import de.btobastian.javacord.utils.PacketHandler;
@@ -40,6 +43,9 @@ public class ChannelDeleteHandler extends PacketHandler {
                 break;
             case 2:
                 handleServerVoiceChannel(packet);
+                break;
+            case 3:
+                handleGroupChannel(packet);
                 break;
             case 4:
                 handleCategory(packet);
@@ -107,6 +113,29 @@ public class ChannelDeleteHandler extends PacketHandler {
             dispatchEvent(listeners, listener -> listener.onPrivateChannelDelete(event));
 
             recipient.setChannel(null);
+        });
+    }
+
+    /**
+     * Handles a group channel deletion.
+     *
+     * @param channel The channel data.
+     */
+    private void handleGroupChannel(JsonNode channel) {
+        long channelId = channel.get("id").asLong();
+
+        api.getGroupChannelById(channelId).ifPresent(groupChannel -> {
+            GroupChannelDeleteEvent event = new GroupChannelDeleteEvent(groupChannel);
+
+            List<GroupChannelDeleteListener> listeners = new ArrayList<>();
+            listeners.addAll(groupChannel.getGroupChannelDeleteListeners());
+            groupChannel.getMembers().stream()
+                    .map(User::getGroupChannelDeleteListeners)
+                    .forEach(listeners::addAll);
+            listeners.addAll(api.getGroupChannelDeleteListeners());
+
+            dispatchEvent(listeners, listener -> listener.onGroupChannelDelete(event));
+            api.removeGroupChannelFromCache(channelId);
         });
     }
 

--- a/src/main/java/de/btobastian/javacord/utils/ratelimits/RatelimitManager.java
+++ b/src/main/java/de/btobastian/javacord/utils/ratelimits/RatelimitManager.java
@@ -4,6 +4,7 @@ import de.btobastian.javacord.DiscordApi;
 import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.exceptions.DiscordException;
 import de.btobastian.javacord.exceptions.RatelimitException;
+import de.btobastian.javacord.utils.Cleanupable;
 import de.btobastian.javacord.utils.ThreadFactory;
 import de.btobastian.javacord.utils.logging.LoggerUtil;
 import de.btobastian.javacord.utils.rest.RestRequest;
@@ -26,7 +27,7 @@ import java.util.function.Function;
 /**
  * This class manages ratelimits and keeps track of them.
  */
-public class RatelimitManager {
+public class RatelimitManager implements Cleanupable {
 
     /**
      * The logger of this class.
@@ -227,4 +228,8 @@ public class RatelimitManager {
         }
     }
 
+    @Override
+    public void cleanup() {
+        scheduler.shutdown();
+    }
 }


### PR DESCRIPTION
Introduced Cleanupable to prevent memory leaks with repetetive scheduled tasks in the central scheduler that should not outlive a reconnect.
As a side effect also improved the private and group channel handling.