### PR TITLE
Improve yourself-checks

### DIFF
--- a/src/main/java/de/btobastian/javacord/entities/User.java
+++ b/src/main/java/de/btobastian/javacord/entities/User.java
@@ -189,7 +189,7 @@ public interface User extends DiscordEntity, Messageable, Mentionable {
      * @see DiscordApi#getYourself()
      */
     default boolean isYourself() {
-        return this == getApi().getYourself();
+        return getId() == getApi().getYourself().getId();
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/message/MessageAuthor.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/MessageAuthor.java
@@ -531,7 +531,7 @@ public interface MessageAuthor extends DiscordEntity {
      * @see DiscordApi#getYourself()
      */
     default boolean isYourself() {
-        return getApi().getYourself().getId() == getId();
+        return asUser().map(User::isYourself).orElse(false);
     }
 
 }


### PR DESCRIPTION
- For User#isYourself() now the ID is compared, this way it also works correctly for instances that were created before a session restart
- For MessageAuthor#isYourself() now User#isYourself() is used, this way it will only return true if the message author actually is a user