### PR TITLE
Message History Improvements

### DIFF
--- a/src/main/java/de/btobastian/javacord/DiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/DiscordApi.java
@@ -23,6 +23,7 @@ import de.btobastian.javacord.entities.impl.ImplApplicationInfo;
 import de.btobastian.javacord.entities.impl.ImplInvite;
 import de.btobastian.javacord.entities.impl.ImplWebhook;
 import de.btobastian.javacord.entities.message.Message;
+import de.btobastian.javacord.entities.message.MessageSet;
 import de.btobastian.javacord.entities.message.emoji.CustomEmoji;
 import de.btobastian.javacord.entities.permissions.Permissions;
 import de.btobastian.javacord.entities.permissions.Role;
@@ -543,11 +544,11 @@ public interface DiscordApi {
     }
 
     /**
-     * Gets a collection with all cached messages.
+     * Gets a message set with all currently cached messages.
      *
-     * @return A collection with all cached messages.
+     * @return A message set with all currently cached messages.
      */
-    Collection<Message> getCachedMessages();
+    MessageSet getCachedMessages();
 
     /**
      * Gets a cached message by its id.

--- a/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
@@ -15,9 +15,11 @@ import de.btobastian.javacord.entities.channels.TextChannel;
 import de.btobastian.javacord.entities.impl.ImplActivity;
 import de.btobastian.javacord.entities.impl.ImplUser;
 import de.btobastian.javacord.entities.message.Message;
+import de.btobastian.javacord.entities.message.MessageSet;
 import de.btobastian.javacord.entities.message.emoji.CustomEmoji;
 import de.btobastian.javacord.entities.message.emoji.impl.ImplCustomEmoji;
 import de.btobastian.javacord.entities.message.impl.ImplMessage;
+import de.btobastian.javacord.entities.message.impl.ImplMessageSet;
 import de.btobastian.javacord.listeners.connection.LostConnectionListener;
 import de.btobastian.javacord.listeners.connection.ReconnectListener;
 import de.btobastian.javacord.listeners.connection.ResumeListener;
@@ -881,12 +883,12 @@ public class ImplDiscordApi implements DiscordApi {
     }
 
     @Override
-    public Collection<Message> getCachedMessages() {
+    public MessageSet getCachedMessages() {
         synchronized (messages) {
-            return messages.values().stream()
-                    .map(Reference::get)
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toList());
+            return new ImplMessageSet(messages.values().stream()
+                                              .map(Reference::get)
+                                              .filter(Objects::nonNull)
+                                              .collect(Collectors.toList()));
         }
     }
 

--- a/src/main/java/de/btobastian/javacord/entities/channels/TextChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/TextChannel.java
@@ -50,6 +50,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
@@ -399,9 +400,23 @@ public interface TextChannel extends Channel, Messageable {
      *
      * @param limit The limit of messages to get.
      * @return The messages.
+     * @see #getMessagesAsStream()
      */
     default CompletableFuture<MessageSet> getMessages(int limit) {
         return ImplMessageSet.getMessages(this, limit);
+    }
+
+    /**
+     * Gets a stream of messages in this channel sorted from newest to oldest.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @return The stream.
+     * @see #getMessages(int)
+     */
+    default Stream<Message> getMessagesAsStream() {
+        return ImplMessageSet.getMessagesAsStream(this);
     }
 
     /**
@@ -410,9 +425,24 @@ public interface TextChannel extends Channel, Messageable {
      * @param limit The limit of messages to get.
      * @param before Get messages before the message with this id.
      * @return The messages.
+     * @see #getMessagesBeforeAsStream(long)
      */
     default CompletableFuture<MessageSet> getMessagesBefore(int limit, long before) {
         return ImplMessageSet.getMessagesBefore(this, limit, before);
+    }
+
+    /**
+     * Gets a stream of messages in this channel before a given message in any channel sorted from newest to oldest.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @param before Get messages before the message with this id.
+     * @return The stream.
+     * @see #getMessagesBefore(int, long)
+     */
+    default Stream<Message> getMessagesBeforeAsStream(long before) {
+        return ImplMessageSet.getMessagesBeforeAsStream(this, before);
     }
 
     /**
@@ -421,9 +451,24 @@ public interface TextChannel extends Channel, Messageable {
      * @param limit The limit of messages to get.
      * @param before Get messages before this message.
      * @return The messages.
+     * @see #getMessagesBeforeAsStream(Message)
      */
     default CompletableFuture<MessageSet> getMessagesBefore(int limit, Message before) {
         return getMessagesBefore(limit, before.getId());
+    }
+
+    /**
+     * Gets a stream of messages in this channel before a given message in any channel sorted from newest to oldest.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @param before Get messages before this message.
+     * @return The stream.
+     * @see #getMessagesBefore(int, Message)
+     */
+    default Stream<Message> getMessagesBeforeAsStream(Message before) {
+        return getMessagesBeforeAsStream(before.getId());
     }
 
     /**
@@ -432,9 +477,24 @@ public interface TextChannel extends Channel, Messageable {
      * @param limit The limit of messages to get.
      * @param after Get messages after the message with this id.
      * @return The messages.
+     * @see #getMessagesAfterAsStream(long)
      */
     default CompletableFuture<MessageSet> getMessagesAfter(int limit, long after) {
         return ImplMessageSet.getMessagesAfter(this, limit, after);
+    }
+
+    /**
+     * Gets a stream of messages in this channel after a given message in any channel sorted from oldest to newest.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @param after Get messages after the message with this id.
+     * @return The messages.
+     * @see #getMessagesAfter(int, long)
+     */
+    default Stream<Message> getMessagesAfterAsStream(long after) {
+        return ImplMessageSet.getMessagesAfterAsStream(this, after);
     }
 
     /**
@@ -443,9 +503,24 @@ public interface TextChannel extends Channel, Messageable {
      * @param limit The limit of messages to get.
      * @param after Get messages after this message.
      * @return The messages.
+     * @see #getMessagesAfterAsStream(Message)
      */
     default CompletableFuture<MessageSet> getMessagesAfter(int limit, Message after) {
         return getMessagesAfter(limit, after.getId());
+    }
+
+    /**
+     * Gets a stream of messages in this channel after a given message in any channel sorted from oldest to newest.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @param after Get messages after this message.
+     * @return The stream.
+     * @see #getMessagesAfter(int, Message)
+     */
+    default Stream<Message> getMessagesAfterAsStream(Message after) {
+        return getMessagesAfterAsStream(after.getId());
     }
 
     /**
@@ -459,9 +534,28 @@ public interface TextChannel extends Channel, Messageable {
      * @param limit The limit of messages to get.
      * @param around Get messages around the message with this id.
      * @return The messages.
+     * @see #getMessagesAroundAsStream(long)
      */
     default CompletableFuture<MessageSet> getMessagesAround(int limit, long around) {
         return ImplMessageSet.getMessagesAround(this, limit, around);
+    }
+
+    /**
+     * Gets a stream of messages in this channel around a given message in any channel.
+     * The first message in the stream will be the given message if it was sent in this channel.
+     * After that you will always get an older message and a newer message alternating as long as on both sides
+     * messages are available. If only on one side further messages are available, only those are delivered further on.
+     * It's not guaranteed to be perfectly balanced.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @param around Get messages around the message with this id.
+     * @return The stream.
+     * @see #getMessagesAround(int, long)
+     */
+    default Stream<Message> getMessagesAroundAsStream(long around) {
+        return ImplMessageSet.getMessagesAroundAsStream(this, around);
     }
 
     /**
@@ -475,9 +569,28 @@ public interface TextChannel extends Channel, Messageable {
      * @param limit The limit of messages to get.
      * @param around Get messages around this message.
      * @return The messages.
+     * @see #getMessagesAroundAsStream(Message)
      */
     default CompletableFuture<MessageSet> getMessagesAround(int limit, Message around) {
         return getMessagesAround(limit, around.getId());
+    }
+
+    /**
+     * Gets a stream of messages in this channel around a given message in any channel.
+     * The first message in the stream will be the given message if it was sent in this channel.
+     * After that you will always get an older message and a newer message alternating as long as on both sides
+     * messages are available. If only on one side further messages are available, only those are delivered further on.
+     * It's not guaranteed to be perfectly balanced.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @param around Get messages around this message.
+     * @return The stream.
+     * @see #getMessagesAround(int, Message)
+     */
+    default Stream<Message> getMessagesAroundAsStream(Message around) {
+        return getMessagesAroundAsStream(around.getId());
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/channels/TextChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/TextChannel.java
@@ -799,6 +799,126 @@ public interface TextChannel extends Channel, Messageable {
     }
 
     /**
+     * Gets all messages in this channel between the first given message in any channel and the second given message in
+     * any channel, excluding the boundaries.
+     *
+     * @param from The id of the start boundary messages.
+     * @param to The id of the other boundary messages.
+     * @return The messages.
+     * @see #getMessagesBetweenAsStream(long, long)
+     */
+    default CompletableFuture<MessageSet> getMessagesBetween(long from, long to) {
+        return ImplMessageSet.getMessagesBetween(this, from, to);
+    }
+
+    /**
+     * Gets all messages in this channel between the first given message in any channel and the second given message in
+     * any channel, excluding the boundaries, until one that meets the given condition is found.
+     * If no message matches the condition, an empty set is returned.
+     *
+     * @param condition The abort condition for when to stop retrieving messages.
+     * @param from The id of the start boundary messages.
+     * @param to The id of the other boundary messages.
+     * @return The messages.
+     * @see #getMessagesBetweenAsStream(long, long)
+     */
+    default CompletableFuture<MessageSet> getMessagesBetweenUntil(Predicate<Message> condition, long from, long to) {
+        return ImplMessageSet.getMessagesBetweenUntil(this, condition, from, to);
+    }
+
+    /**
+     * Gets all messages in this channel between the first given message in any channel and the second given message in
+     * any channel, excluding the boundaries, while they meet the given condition.
+     * If the first message does not match the condition, an empty set is returned.
+     *
+     * @param condition The condition that has to be met.
+     * @param from The id of the start boundary messages.
+     * @param to The id of the other boundary messages.
+     * @return The messages.
+     * @see #getMessagesBetweenAsStream(long, long)
+     */
+    default CompletableFuture<MessageSet> getMessagesBetweenWhile(Predicate<Message> condition, long from, long to) {
+        return ImplMessageSet.getMessagesBetweenWhile(this, condition, from, to);
+    }
+
+    /**
+     * Gets all messages in this channel between the first given message in any channel and the second given message in
+     * any channel, excluding the boundaries, sorted from first given message to the second given message.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @param from The id of the start boundary messages.
+     * @param to The id of the other boundary messages.
+     * @return The stream.
+     * @see #getMessagesBetween(long, long)
+     */
+    default Stream<Message> getMessagesBetweenAsStream(long from, long to) {
+        return ImplMessageSet.getMessagesBetweenAsStream(this, from, to);
+    }
+
+    /**
+     * Gets all messages in this channel between the first given message in any channel and the second given message in
+     * any channel, excluding the boundaries.
+     *
+     * @param from The start boundary messages.
+     * @param to The other boundary messages.
+     * @return The messages.
+     * @see #getMessagesBetweenAsStream(long, long)
+     */
+    default CompletableFuture<MessageSet> getMessagesBetween(Message from, Message to) {
+        return getMessagesBetween(from.getId(), to.getId());
+    }
+
+    /**
+     * Gets all messages in this channel between the first given message in any channel and the second given message in
+     * any channel, excluding the boundaries, until one that meets the given condition is found.
+     * If no message matches the condition, an empty set is returned.
+     *
+     * @param condition The abort condition for when to stop retrieving messages.
+     * @param from The start boundary messages.
+     * @param to The other boundary messages.
+     * @return The messages.
+     * @see #getMessagesBetweenAsStream(long, long)
+     */
+    default CompletableFuture<MessageSet> getMessagesBetweenUntil(
+            Predicate<Message> condition, Message from, Message to) {
+        return getMessagesBetweenUntil(condition, from.getId(), to.getId());
+    }
+
+    /**
+     * Gets all messages in this channel between the first given message in any channel and the second given message in
+     * any channel, excluding the boundaries, while they meet the given condition.
+     * If the first message does not match the condition, an empty set is returned.
+     *
+     * @param condition The condition that has to be met.
+     * @param from The start boundary messages.
+     * @param to The other boundary messages.
+     * @return The messages.
+     * @see #getMessagesBetweenAsStream(long, long)
+     */
+    default CompletableFuture<MessageSet> getMessagesBetweenWhile(
+            Predicate<Message> condition, Message from, Message to) {
+        return getMessagesBetweenWhile(condition, from.getId(), to.getId());
+    }
+
+    /**
+     * Gets all messages in this channel between the first given message in any channel and the second given message in
+     * any channel, excluding the boundaries, sorted from first given message to the second given message.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @param from The start boundary messages.
+     * @param to The other boundary messages.
+     * @return The stream.
+     * @see #getMessagesBetween(long, long)
+     */
+    default Stream<Message> getMessagesBetweenAsStream(Message from, Message to) {
+        return getMessagesBetweenAsStream(from.getId(), to.getId());
+    }
+
+    /**
      * Gets the message cache for the channel.
      *
      * @return The message cache for the channel.

--- a/src/main/java/de/btobastian/javacord/entities/channels/TextChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/TextChannel.java
@@ -10,10 +10,10 @@ import de.btobastian.javacord.entities.User;
 import de.btobastian.javacord.entities.Webhook;
 import de.btobastian.javacord.entities.impl.ImplWebhook;
 import de.btobastian.javacord.entities.message.Message;
-import de.btobastian.javacord.entities.message.MessageHistory;
+import de.btobastian.javacord.entities.message.MessageSet;
 import de.btobastian.javacord.entities.message.Messageable;
 import de.btobastian.javacord.entities.message.embed.EmbedBuilder;
-import de.btobastian.javacord.entities.message.impl.ImplMessageHistory;
+import de.btobastian.javacord.entities.message.impl.ImplMessageSet;
 import de.btobastian.javacord.entities.permissions.PermissionType;
 import de.btobastian.javacord.listeners.message.MessageCreateListener;
 import de.btobastian.javacord.listeners.message.MessageDeleteListener;
@@ -399,8 +399,8 @@ public interface TextChannel extends Channel, Messageable {
      * @param limit The limit of messages to get.
      * @return The history.
      */
-    default CompletableFuture<MessageHistory> getHistory(int limit) {
-        return ImplMessageHistory.getHistory(this, limit);
+    default CompletableFuture<MessageSet> getHistory(int limit) {
+        return ImplMessageSet.getHistory(this, limit);
     }
 
     /**
@@ -410,8 +410,8 @@ public interface TextChannel extends Channel, Messageable {
      * @param before Get messages before the message with this id.
      * @return The history.
      */
-    default CompletableFuture<MessageHistory> getHistoryBefore(int limit, long before) {
-        return ImplMessageHistory.getHistoryBefore(this, limit, before);
+    default CompletableFuture<MessageSet> getHistoryBefore(int limit, long before) {
+        return ImplMessageSet.getHistoryBefore(this, limit, before);
     }
 
     /**
@@ -421,7 +421,7 @@ public interface TextChannel extends Channel, Messageable {
      * @param before Get messages before this message.
      * @return The history.
      */
-    default CompletableFuture<MessageHistory> getHistoryBefore(int limit, Message before) {
+    default CompletableFuture<MessageSet> getHistoryBefore(int limit, Message before) {
         return getHistoryBefore(limit, before.getId());
     }
 
@@ -432,8 +432,8 @@ public interface TextChannel extends Channel, Messageable {
      * @param after Get messages after the message with this id.
      * @return The history.
      */
-    default CompletableFuture<MessageHistory> getHistoryAfter(int limit, long after) {
-        return ImplMessageHistory.getHistoryAfter(this, limit, after);
+    default CompletableFuture<MessageSet> getHistoryAfter(int limit, long after) {
+        return ImplMessageSet.getHistoryAfter(this, limit, after);
     }
 
     /**
@@ -443,7 +443,7 @@ public interface TextChannel extends Channel, Messageable {
      * @param after Get messages after this message.
      * @return The history.
      */
-    default CompletableFuture<MessageHistory> getHistoryAfter(int limit, Message after) {
+    default CompletableFuture<MessageSet> getHistoryAfter(int limit, Message after) {
         return getHistoryAfter(limit, after.getId());
     }
     /**
@@ -456,8 +456,8 @@ public interface TextChannel extends Channel, Messageable {
      * @param around Get messages around the message with this id.
      * @return The history.
      */
-    default CompletableFuture<MessageHistory> getHistoryAround(int limit, long around) {
-        return ImplMessageHistory.getHistoryAround(this, limit, around);
+    default CompletableFuture<MessageSet> getHistoryAround(int limit, long around) {
+        return ImplMessageSet.getHistoryAround(this, limit, around);
     }
 
     /**
@@ -470,7 +470,7 @@ public interface TextChannel extends Channel, Messageable {
      * @param around Get messages around this message.
      * @return The history.
      */
-    default CompletableFuture<MessageHistory> getHistoryAround(int limit, Message around) {
+    default CompletableFuture<MessageSet> getHistoryAround(int limit, Message around) {
         return getHistoryAround(limit, around.getId());
     }
 

--- a/src/main/java/de/btobastian/javacord/entities/channels/TextChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/TextChannel.java
@@ -48,6 +48,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
@@ -407,6 +408,18 @@ public interface TextChannel extends Channel, Messageable {
     }
 
     /**
+     * Gets messages in this channel from the newer end until one that meets the given condition is found.
+     * If no message matches the condition, an empty set is returned.
+     *
+     * @param condition The abort condition for when to stop retrieving messages.
+     * @return The messages.
+     * @see #getMessagesAsStream()
+     */
+    default CompletableFuture<MessageSet> getMessagesUntil(Predicate<Message> condition) {
+        return ImplMessageSet.getMessagesUntil(this, condition);
+    }
+
+    /**
      * Gets a stream of messages in this channel sorted from newest to oldest.
      * <p>
      * The messages are retrieved in batches synchronously from Discord,
@@ -429,6 +442,20 @@ public interface TextChannel extends Channel, Messageable {
      */
     default CompletableFuture<MessageSet> getMessagesBefore(int limit, long before) {
         return ImplMessageSet.getMessagesBefore(this, limit, before);
+    }
+
+    /**
+     * Gets messages in this channel before a given message in any channel until one that meets the given condition is
+     * found.
+     * If no message matches the condition, an empty set is returned.
+     *
+     * @param condition The abort condition for when to stop retrieving messages.
+     * @param before Get messages before the message with this id.
+     * @return The messages.
+     * @see #getMessagesBeforeAsStream(long)
+     */
+    default CompletableFuture<MessageSet> getMessagesBeforeUntil(Predicate<Message> condition, long before) {
+        return ImplMessageSet.getMessagesBeforeUntil(this, condition, before);
     }
 
     /**
@@ -458,6 +485,20 @@ public interface TextChannel extends Channel, Messageable {
     }
 
     /**
+     * Gets messages in this channel before a given message in any channel until one that meets the given condition is
+     * found.
+     * If no message matches the condition, an empty set is returned.
+     *
+     * @param condition The abort condition for when to stop retrieving messages.
+     * @param before Get messages before this message.
+     * @return The messages.
+     * @see #getMessagesBeforeAsStream(Message)
+     */
+    default CompletableFuture<MessageSet> getMessagesBeforeUntil(Predicate<Message> condition, Message before) {
+        return getMessagesBeforeUntil(condition, before.getId());
+    }
+
+    /**
      * Gets a stream of messages in this channel before a given message in any channel sorted from newest to oldest.
      * <p>
      * The messages are retrieved in batches synchronously from Discord,
@@ -484,6 +525,20 @@ public interface TextChannel extends Channel, Messageable {
     }
 
     /**
+     * Gets messages in this channel after a given message in any channel until one that meets the given condition is
+     * found.
+     * If no message matches the condition, an empty set is returned.
+     *
+     * @param condition The abort condition for when to stop retrieving messages.
+     * @param after Get messages after the message with this id.
+     * @return The messages.
+     * @see #getMessagesAfterAsStream(long)
+     */
+    default CompletableFuture<MessageSet> getMessagesAfterUntil(Predicate<Message> condition, long after) {
+        return ImplMessageSet.getMessagesAfterUntil(this, condition, after);
+    }
+
+    /**
      * Gets a stream of messages in this channel after a given message in any channel sorted from oldest to newest.
      * <p>
      * The messages are retrieved in batches synchronously from Discord,
@@ -507,6 +562,20 @@ public interface TextChannel extends Channel, Messageable {
      */
     default CompletableFuture<MessageSet> getMessagesAfter(int limit, Message after) {
         return getMessagesAfter(limit, after.getId());
+    }
+
+    /**
+     * Gets messages in this channel after a given message in any channel until one that meets the given condition is
+     * found.
+     * If no message matches the condition, an empty set is returned.
+     *
+     * @param condition The abort condition for when to stop retrieving messages.
+     * @param after Get messages after this message.
+     * @return The messages.
+     * @see #getMessagesAfterAsStream(Message)
+     */
+    default CompletableFuture<MessageSet> getMessagesAfterUntil(Predicate<Message> condition, Message after) {
+        return getMessagesAfterUntil(condition, after.getId());
     }
 
     /**
@@ -538,6 +607,24 @@ public interface TextChannel extends Channel, Messageable {
      */
     default CompletableFuture<MessageSet> getMessagesAround(int limit, long around) {
         return ImplMessageSet.getMessagesAround(this, limit, around);
+    }
+
+    /**
+     * Gets messages in this channel around a given message in any channel until one that meets the given condition is
+     * found. If no message matches the condition, an empty set is returned.
+     * The given message will be part of the result in addition to the messages around if it was sent in this channel
+     * and is matched against the condition and will abort retrieval.
+     * Half of the messages will be older than the given message and half of the messages will be newer.
+     * If there aren't enough older or newer messages, the actual amount of messages will be less than the given limit.
+     * It's also not guaranteed to be perfectly balanced.
+     *
+     * @param condition The abort condition for when to stop retrieving messages.
+     * @param around Get messages around the message with this id.
+     * @return The messages.
+     * @see #getMessagesAroundAsStream(long)
+     */
+    default CompletableFuture<MessageSet> getMessagesAroundUntil(Predicate<Message> condition, long around) {
+        return ImplMessageSet.getMessagesAroundUntil(this, condition, around);
     }
 
     /**
@@ -573,6 +660,24 @@ public interface TextChannel extends Channel, Messageable {
      */
     default CompletableFuture<MessageSet> getMessagesAround(int limit, Message around) {
         return getMessagesAround(limit, around.getId());
+    }
+
+    /**
+     * Gets messages in this channel around a given message in any channel until one that meets the given condition is
+     * found. If no message matches the condition, an empty set is returned.
+     * The given message will be part of the result in addition to the messages around if it was sent in this channel
+     * and is matched against the condition and will abort retrieval.
+     * Half of the messages will be older than the given message and half of the messages will be newer.
+     * If there aren't enough older or newer messages, the actual amount of messages will be less than the given limit.
+     * It's also not guaranteed to be perfectly balanced.
+     *
+     * @param condition The abort condition for when to stop retrieving messages.
+     * @param around Get messages around this message.
+     * @return The messages.
+     * @see #getMessagesAroundAsStream(Message)
+     */
+    default CompletableFuture<MessageSet> getMessagesAroundUntil(Predicate<Message> condition, Message around) {
+        return getMessagesAroundUntil(condition, around.getId());
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/channels/TextChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/TextChannel.java
@@ -420,6 +420,18 @@ public interface TextChannel extends Channel, Messageable {
     }
 
     /**
+     * Gets messages in this channel from the newer end while they meet the given condition.
+     * If the first message does not match the condition, an empty set is returned.
+     *
+     * @param condition The condition that has to be met.
+     * @return The messages.
+     * @see #getMessagesAsStream()
+     */
+    default CompletableFuture<MessageSet> getMessagesWhile(Predicate<Message> condition) {
+        return ImplMessageSet.getMessagesWhile(this, condition);
+    }
+
+    /**
      * Gets a stream of messages in this channel sorted from newest to oldest.
      * <p>
      * The messages are retrieved in batches synchronously from Discord,
@@ -456,6 +468,19 @@ public interface TextChannel extends Channel, Messageable {
      */
     default CompletableFuture<MessageSet> getMessagesBeforeUntil(Predicate<Message> condition, long before) {
         return ImplMessageSet.getMessagesBeforeUntil(this, condition, before);
+    }
+
+    /**
+     * Gets messages in this channel before a given message in any channel while they meet the given condition.
+     * If the first message does not match the condition, an empty set is returned.
+     *
+     * @param condition The condition that has to be met.
+     * @param before Get messages before the message with this id.
+     * @return The messages.
+     * @see #getMessagesBeforeAsStream(long)
+     */
+    default CompletableFuture<MessageSet> getMessagesBeforeWhile(Predicate<Message> condition, long before) {
+        return ImplMessageSet.getMessagesBeforeWhile(this, condition, before);
     }
 
     /**
@@ -499,6 +524,19 @@ public interface TextChannel extends Channel, Messageable {
     }
 
     /**
+     * Gets messages in this channel before a given message in any channel while they meet the given condition.
+     * If the first message does not match the condition, an empty set is returned.
+     *
+     * @param condition The condition that has to be met.
+     * @param before Get messages before this message.
+     * @return The messages.
+     * @see #getMessagesBeforeAsStream(Message)
+     */
+    default CompletableFuture<MessageSet> getMessagesBeforeWhile(Predicate<Message> condition, Message before) {
+        return getMessagesBeforeWhile(condition, before.getId());
+    }
+
+    /**
      * Gets a stream of messages in this channel before a given message in any channel sorted from newest to oldest.
      * <p>
      * The messages are retrieved in batches synchronously from Discord,
@@ -539,6 +577,19 @@ public interface TextChannel extends Channel, Messageable {
     }
 
     /**
+     * Gets messages in this channel after a given message in any channel while they meet the given condition.
+     * If the first message does not match the condition, an empty set is returned.
+     *
+     * @param condition The condition that has to be met.
+     * @param after Get messages after the message with this id.
+     * @return The messages.
+     * @see #getMessagesAfterAsStream(long)
+     */
+    default CompletableFuture<MessageSet> getMessagesAfterWhile(Predicate<Message> condition, long after) {
+        return ImplMessageSet.getMessagesAfterWhile(this, condition, after);
+    }
+
+    /**
      * Gets a stream of messages in this channel after a given message in any channel sorted from oldest to newest.
      * <p>
      * The messages are retrieved in batches synchronously from Discord,
@@ -576,6 +627,19 @@ public interface TextChannel extends Channel, Messageable {
      */
     default CompletableFuture<MessageSet> getMessagesAfterUntil(Predicate<Message> condition, Message after) {
         return getMessagesAfterUntil(condition, after.getId());
+    }
+
+    /**
+     * Gets messages in this channel after a given message in any channel while they meet the given condition.
+     * If the first message does not match the condition, an empty set is returned.
+     *
+     * @param condition The condition that has to be met.
+     * @param after Get messages after this message.
+     * @return The messages.
+     * @see #getMessagesAfterAsStream(Message)
+     */
+    default CompletableFuture<MessageSet> getMessagesAfterWhile(Predicate<Message> condition, Message after) {
+        return getMessagesAfterWhile(condition, after.getId());
     }
 
     /**
@@ -625,6 +689,24 @@ public interface TextChannel extends Channel, Messageable {
      */
     default CompletableFuture<MessageSet> getMessagesAroundUntil(Predicate<Message> condition, long around) {
         return ImplMessageSet.getMessagesAroundUntil(this, condition, around);
+    }
+
+    /**
+     * Gets messages in this channel around a given message in any channel while they meet the given condition.
+     * If the first message does not match the condition, an empty set is returned.
+     * The given message will be part of the result in addition to the messages around if it was sent in this channel
+     * and is matched against the condition and will abort retrieval.
+     * Half of the messages will be older than the given message and half of the messages will be newer.
+     * If there aren't enough older or newer messages, the actual amount of messages will be less than the given limit.
+     * It's also not guaranteed to be perfectly balanced.
+     *
+     * @param condition The condition that has to be met.
+     * @param around Get messages around the message with this id.
+     * @return The messages.
+     * @see #getMessagesAroundAsStream(long)
+     */
+    default CompletableFuture<MessageSet> getMessagesAroundWhile(Predicate<Message> condition, long around) {
+        return ImplMessageSet.getMessagesAroundWhile(this, condition, around);
     }
 
     /**
@@ -678,6 +760,24 @@ public interface TextChannel extends Channel, Messageable {
      */
     default CompletableFuture<MessageSet> getMessagesAroundUntil(Predicate<Message> condition, Message around) {
         return getMessagesAroundUntil(condition, around.getId());
+    }
+
+    /**
+     * Gets messages in this channel around a given message in any channel while they meet the given condition.
+     * If the first message does not match the condition, an empty set is returned.
+     * The given message will be part of the result in addition to the messages around if it was sent in this channel
+     * and is matched against the condition and will abort retrieval.
+     * Half of the messages will be older than the given message and half of the messages will be newer.
+     * If there aren't enough older or newer messages, the actual amount of messages will be less than the given limit.
+     * It's also not guaranteed to be perfectly balanced.
+     *
+     * @param condition The condition that has to be met.
+     * @param around Get messages around this message.
+     * @return The messages.
+     * @see #getMessagesAroundAsStream(Message)
+     */
+    default CompletableFuture<MessageSet> getMessagesAroundWhile(Predicate<Message> condition, Message around) {
+        return getMessagesAroundWhile(condition, around.getId());
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/channels/TextChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/TextChannel.java
@@ -394,84 +394,89 @@ public interface TextChannel extends Channel, Messageable {
     }
 
     /**
-     * Gets the history of messages in this channel.
+     * Gets up to a given amount of messages in this channel from the newer end.
      *
      * @param limit The limit of messages to get.
-     * @return The history.
+     * @return The messages.
      */
-    default CompletableFuture<MessageSet> getHistory(int limit) {
-        return ImplMessageSet.getHistory(this, limit);
+    default CompletableFuture<MessageSet> getMessages(int limit) {
+        return ImplMessageSet.getMessages(this, limit);
     }
 
     /**
-     * Gets the history of messages before a given message in this channel.
+     * Gets up to a given amount of messages in this channel before a given message in any channel.
      *
      * @param limit The limit of messages to get.
      * @param before Get messages before the message with this id.
-     * @return The history.
+     * @return The messages.
      */
-    default CompletableFuture<MessageSet> getHistoryBefore(int limit, long before) {
-        return ImplMessageSet.getHistoryBefore(this, limit, before);
+    default CompletableFuture<MessageSet> getMessagesBefore(int limit, long before) {
+        return ImplMessageSet.getMessagesBefore(this, limit, before);
     }
 
     /**
-     * Gets the history of messages before a given message in this channel.
+     * Gets up to a given amount of messages in this channel before a given message in any channel.
      *
      * @param limit The limit of messages to get.
      * @param before Get messages before this message.
-     * @return The history.
+     * @return The messages.
      */
-    default CompletableFuture<MessageSet> getHistoryBefore(int limit, Message before) {
-        return getHistoryBefore(limit, before.getId());
+    default CompletableFuture<MessageSet> getMessagesBefore(int limit, Message before) {
+        return getMessagesBefore(limit, before.getId());
     }
 
     /**
-     * Gets the history of messages after a given message in this channel.
+     * Gets up to a given amount of messages in this channel after a given message in any channel.
      *
      * @param limit The limit of messages to get.
      * @param after Get messages after the message with this id.
-     * @return The history.
+     * @return The messages.
      */
-    default CompletableFuture<MessageSet> getHistoryAfter(int limit, long after) {
-        return ImplMessageSet.getHistoryAfter(this, limit, after);
+    default CompletableFuture<MessageSet> getMessagesAfter(int limit, long after) {
+        return ImplMessageSet.getMessagesAfter(this, limit, after);
     }
 
     /**
-     * Gets the history of messages after a given message in this channel.
+     * Gets up to a given amount of messages in this channel after a given message in any channel.
      *
      * @param limit The limit of messages to get.
      * @param after Get messages after this message.
-     * @return The history.
+     * @return The messages.
      */
-    default CompletableFuture<MessageSet> getHistoryAfter(int limit, Message after) {
-        return getHistoryAfter(limit, after.getId());
+    default CompletableFuture<MessageSet> getMessagesAfter(int limit, Message after) {
+        return getMessagesAfter(limit, after.getId());
     }
+
     /**
-     * Gets the history of messages around a given message in this channel.
-     * Half of the message will be older than the given message and half of the message will be newer.
+     * Gets up to a given amount of messages in this channel around a given message in any channel.
+     * The given message will be part of the result in addition to the messages around if it was sent in this channel
+     * and does not count towards the limit.
+     * Half of the messages will be older than the given message and half of the messages will be newer.
      * If there aren't enough older or newer messages, the actual amount of messages will be less than the given limit.
      * It's also not guaranteed to be perfectly balanced.
      *
      * @param limit The limit of messages to get.
      * @param around Get messages around the message with this id.
-     * @return The history.
+     * @return The messages.
      */
-    default CompletableFuture<MessageSet> getHistoryAround(int limit, long around) {
-        return ImplMessageSet.getHistoryAround(this, limit, around);
+    default CompletableFuture<MessageSet> getMessagesAround(int limit, long around) {
+        return ImplMessageSet.getMessagesAround(this, limit, around);
     }
 
     /**
-     * Gets the history of messages around a given message in this channel.
-     * Half of the message will be older than the given message and half of the message will be newer.
+     * Gets up to a given amount of messages in this channel around a given message in any channel.
+     * The given message will be part of the result in addition to the messages around if it was sent in this channel
+     * and does not count towards the limit.
+     * Half of the messages will be older than the given message and half of the messages will be newer.
      * If there aren't enough older or newer messages, the actual amount of messages will be less than the given limit.
      * It's also not guaranteed to be perfectly balanced.
      *
      * @param limit The limit of messages to get.
      * @param around Get messages around this message.
-     * @return The history.
+     * @return The messages.
      */
-    default CompletableFuture<MessageSet> getHistoryAround(int limit, Message around) {
-        return getHistoryAround(limit, around.getId());
+    default CompletableFuture<MessageSet> getMessagesAround(int limit, Message around) {
+        return getMessagesAround(limit, around.getId());
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/message/Message.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/Message.java
@@ -851,6 +851,19 @@ public interface Message extends DiscordEntity, Comparable<Message> {
     }
 
     /**
+     * Gets messages before this message while they meet the given condition.
+     * If the first message does not match the condition, an empty set is returned.
+     *
+     * @param condition The condition that has to be met.
+     * @return The messages.
+     * @see TextChannel#getMessagesBeforeWhile(Predicate, long)
+     * @see #getMessagesBeforeAsStream()
+     */
+    default CompletableFuture<MessageSet> getMessagesBeforeWhile(Predicate<Message> condition) {
+        return getChannel().getMessagesBeforeWhile(condition, this);
+    }
+
+    /**
      * Gets a stream of messages before this message sorted from newest to oldest.
      * <p>
      * The messages are retrieved in batches synchronously from Discord,
@@ -887,6 +900,19 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      */
     default CompletableFuture<MessageSet> getMessagesAfterUntil(Predicate<Message> condition) {
         return getChannel().getMessagesAfterUntil(condition, this);
+    }
+
+    /**
+     * Gets messages after this message while they meet the given condition.
+     * If the first message does not match the condition, an empty set is returned.
+     *
+     * @param condition The condition that has to be met.
+     * @return The messages.
+     * @see TextChannel#getMessagesAfterWhile(Predicate, long)
+     * @see #getMessagesAfterAsStream()
+     */
+    default CompletableFuture<MessageSet> getMessagesAfterWhile(Predicate<Message> condition) {
+        return getChannel().getMessagesAfterWhile(condition, this);
     }
 
     /**
@@ -935,6 +961,24 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      */
     default CompletableFuture<MessageSet> getMessagesAroundUntil(Predicate<Message> condition) {
         return getChannel().getMessagesAroundUntil(condition, this);
+    }
+
+    /**
+     * Gets messages around this message while they meet the given condition.
+     * If this message does not match the condition, an empty set is returned.
+     * This message will be part of the result in addition to the messages around and is matched against the condition
+     * and will abort retrieval.
+     * Half of the messages will be older than this message and half of the message will be newer.
+     * If there aren't enough older or newer messages, the actual amount of messages will be less than the given limit.
+     * It's also not guaranteed to be perfectly balanced.
+     *
+     * @param condition The condition that has to be met.
+     * @return The messages.
+     * @see TextChannel#getMessagesAroundWhile(Predicate, long)
+     * @see #getMessagesAroundAsStream()
+     */
+    default CompletableFuture<MessageSet> getMessagesAroundWhile(Predicate<Message> condition) {
+        return getChannel().getMessagesAroundWhile(condition, this);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/message/Message.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/Message.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 /**
  * This class represents a Discord message.
@@ -829,9 +830,24 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @param limit The limit of messages to get.
      * @return The messages.
      * @see TextChannel#getMessagesBefore(int, long)
+     * @see #getMessagesBeforeAsStream()
      */
     default CompletableFuture<MessageSet> getMessagesBefore(int limit) {
         return getChannel().getMessagesBefore(limit, this);
+    }
+
+    /**
+     * Gets a stream of messages before this message sorted from newest to oldest.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @return The stream.
+     * @see TextChannel#getMessagesBeforeAsStream(long)
+     * @see #getMessagesBefore(int)
+     */
+    default Stream<Message> getMessagesBeforeAsStream() {
+        return getChannel().getMessagesBeforeAsStream(this);
     }
 
     /**
@@ -840,9 +856,24 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @param limit The limit of messages to get.
      * @return The messages.
      * @see TextChannel#getMessagesAfter(int, long)
+     * @see #getMessagesAfterAsStream()
      */
     default CompletableFuture<MessageSet> getMessagesAfter(int limit) {
         return getChannel().getMessagesAfter(limit, this);
+    }
+
+    /**
+     * Gets a stream of messages after this message sorted from oldest to newest.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @return The stream.
+     * @see TextChannel#getMessagesAfterAsStream(long)
+     * @see #getMessagesAfter(int)
+     */
+    default Stream<Message> getMessagesAfterAsStream() {
+        return getChannel().getMessagesAfterAsStream(this);
     }
 
     /**
@@ -855,9 +886,27 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @param limit The limit of messages to get.
      * @return The messages.
      * @see TextChannel#getMessagesAround(int, long)
+     * @see #getMessagesAroundAsStream()
      */
     default CompletableFuture<MessageSet> getMessagesAround(int limit) {
         return getChannel().getMessagesAround(limit, this);
+    }
+
+    /**
+     * Gets a stream of messages around this message. The first message in the stream will be this message.
+     * After that you will always get an older message and a newer message alternating as long as on both sides
+     * messages are available. If only on one side further messages are available, only those are delivered further on.
+     * It's not guaranteed to be perfectly balanced.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @return The stream.
+     * @see TextChannel#getMessagesAroundAsStream(long)
+     * @see #getMessagesAround(int)
+     */
+    default Stream<Message> getMessagesAroundAsStream() {
+        return getChannel().getMessagesAroundAsStream(this);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/message/Message.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/Message.java
@@ -824,39 +824,40 @@ public interface Message extends DiscordEntity, Comparable<Message> {
     }
 
     /**
-     * Gets the history of messages before this message.
+     * Gets up to a given amount of messages before this message.
      *
      * @param limit The limit of messages to get.
-     * @return The history.
-     * @see TextChannel#getHistoryBefore(int, long)
+     * @return The messages.
+     * @see TextChannel#getMessagesBefore(int, long)
      */
-    default CompletableFuture<MessageSet> getHistoryBefore(int limit) {
-        return getChannel().getHistoryBefore(limit, this);
+    default CompletableFuture<MessageSet> getMessagesBefore(int limit) {
+        return getChannel().getMessagesBefore(limit, this);
     }
 
     /**
-     * Gets the history of messages after this message.
+     * Gets up to a given amount of messages after this message.
      *
      * @param limit The limit of messages to get.
-     * @return The history.
-     * @see TextChannel#getHistoryAfter(int, long)
+     * @return The messages.
+     * @see TextChannel#getMessagesAfter(int, long)
      */
-    default CompletableFuture<MessageSet> getHistoryAfter(int limit) {
-        return getChannel().getHistoryAfter(limit, this);
+    default CompletableFuture<MessageSet> getMessagesAfter(int limit) {
+        return getChannel().getMessagesAfter(limit, this);
     }
 
     /**
-     * Gets the history of messages around this message.
-     * Half of the message will be older than the given message and half of the message will be newer.
+     * Gets up to a given amount of messages around this message.
+     * This message will be part of the result in addition to the messages around and does not count towards the limit.
+     * Half of the messages will be older than this message and half of the message will be newer.
      * If there aren't enough older or newer messages, the actual amount of messages will be less than the given limit.
      * It's also not guaranteed to be perfectly balanced.
      *
      * @param limit The limit of messages to get.
-     * @return The history.
-     * @see TextChannel#getHistoryAround(int, long)
+     * @return The messages.
+     * @see TextChannel#getMessagesAround(int, long)
      */
-    default CompletableFuture<MessageSet> getHistoryAround(int limit) {
-        return getChannel().getHistoryAround(limit, this);
+    default CompletableFuture<MessageSet> getMessagesAround(int limit) {
+        return getChannel().getMessagesAround(limit, this);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/message/Message.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/Message.java
@@ -830,7 +830,7 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @return The history.
      * @see TextChannel#getHistoryBefore(int, long)
      */
-    default CompletableFuture<MessageHistory> getHistoryBefore(int limit) {
+    default CompletableFuture<MessageSet> getHistoryBefore(int limit) {
         return getChannel().getHistoryBefore(limit, this);
     }
 
@@ -841,7 +841,7 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @return The history.
      * @see TextChannel#getHistoryAfter(int, long)
      */
-    default CompletableFuture<MessageHistory> getHistoryAfter(int limit) {
+    default CompletableFuture<MessageSet> getHistoryAfter(int limit) {
         return getChannel().getHistoryAfter(limit, this);
     }
 
@@ -855,7 +855,7 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @return The history.
      * @see TextChannel#getHistoryAround(int, long)
      */
-    default CompletableFuture<MessageHistory> getHistoryAround(int limit) {
+    default CompletableFuture<MessageSet> getHistoryAround(int limit) {
         return getChannel().getHistoryAround(limit, this);
     }
 

--- a/src/main/java/de/btobastian/javacord/entities/message/Message.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/Message.java
@@ -999,6 +999,122 @@ public interface Message extends DiscordEntity, Comparable<Message> {
     }
 
     /**
+     * Gets all messages between this messages and the given message, excluding the boundaries.
+     *
+     * @param other The id of the other boundary messages.
+     * @return The messages.
+     * @see TextChannel#getMessagesBetween(long, long)
+     * @see #getMessagesBetweenAsStream(long)
+     */
+    default CompletableFuture<MessageSet> getMessagesBetween(long other) {
+        return getChannel().getMessagesBetween(getId(), other);
+    }
+
+    /**
+     * Gets all messages between this message and the given message, excluding the boundaries, until one that meets the
+     * given condition is found.
+     * If no message matches the condition, an empty set is returned.
+     *
+     * @param other The id of the other boundary messages.
+     * @param condition The abort condition for when to stop retrieving messages.
+     * @return The messages.
+     * @see TextChannel#getMessagesBetweenUntil(Predicate, long, long)
+     * @see #getMessagesBetweenAsStream(long)
+     */
+    default CompletableFuture<MessageSet> getMessagesBetweenUntil(long other, Predicate<Message> condition) {
+        return getChannel().getMessagesBetweenUntil(condition, getId(), other);
+    }
+
+    /**
+     * Gets all messages between this message and the given message, excluding the boundaries, while they meet the
+     * given condition.
+     * If the first message does not match the condition, an empty set is returned.
+     *
+     * @param other The id of the other boundary messages.
+     * @param condition The condition that has to be met.
+     * @return The messages.
+     * @see TextChannel#getMessagesBetweenWhile(Predicate, long, long)
+     * @see #getMessagesBetweenAsStream(long)
+     */
+    default CompletableFuture<MessageSet> getMessagesBetweenWhile(long other, Predicate<Message> condition) {
+        return getChannel().getMessagesBetweenWhile(condition, getId(), other);
+    }
+
+    /**
+     * Gets a stream of all messages between this message and the given message, excluding the boundaries, sorted from
+     * this message to the given message.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @param other The id of the other boundary messages.
+     * @return The stream.
+     * @see TextChannel#getMessagesBetweenAsStream(long, long)
+     * @see #getMessagesBetween(long)
+     */
+    default Stream<Message> getMessagesBetweenAsStream(long other) {
+        return getChannel().getMessagesBetweenAsStream(getId(), other);
+    }
+
+    /**
+     * Gets all messages between this messages and the given message, excluding the boundaries.
+     *
+     * @param other The other boundary messages.
+     * @return The messages.
+     * @see TextChannel#getMessagesBetween(long, long)
+     * @see #getMessagesBetweenAsStream(long)
+     */
+    default CompletableFuture<MessageSet> getMessagesBetween(Message other) {
+        return getMessagesBetween(other.getId());
+    }
+
+    /**
+     * Gets all messages between this message and the given message, excluding the boundaries, until one that meets the
+     * given condition is found.
+     * If no message matches the condition, an empty set is returned.
+     *
+     * @param other The other boundary messages.
+     * @param condition The abort condition for when to stop retrieving messages.
+     * @return The messages.
+     * @see TextChannel#getMessagesBetweenUntil(Predicate, long, long)
+     * @see #getMessagesBetweenAsStream(long)
+     */
+    default CompletableFuture<MessageSet> getMessagesBetweenUntil(Message other, Predicate<Message> condition) {
+        return getMessagesBetweenUntil(other.getId(), condition);
+    }
+
+    /**
+     * Gets all messages between this message and the given message, excluding the boundaries, while they meet the
+     * given condition.
+     * If the first message does not match the condition, an empty set is returned.
+     *
+     * @param other The other boundary messages.
+     * @param condition The condition that has to be met.
+     * @return The messages.
+     * @see TextChannel#getMessagesBetweenWhile(Predicate, long, long)
+     * @see #getMessagesBetweenAsStream(long)
+     */
+    default CompletableFuture<MessageSet> getMessagesBetweenWhile(Message other, Predicate<Message> condition) {
+        return getMessagesBetweenWhile(other.getId(), condition);
+    }
+
+    /**
+     * Gets a stream of all messages between this message and the given message, excluding the boundaries, sorted from
+     * this message to the given message.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @param other The other boundary messages.
+     * @return The stream.
+     * @see TextChannel#getMessagesBetweenAsStream(long, long)
+     * @see #getMessagesBetween(long)
+     */
+    default Stream<Message> getMessagesBetweenAsStream(Message other) {
+        return getMessagesBetweenAsStream(other.getId());
+    }
+
+    /**
      * Checks if the given user is allowed to add <b>new</b> reactions to the message.
      *
      * @param user The user to check.

--- a/src/main/java/de/btobastian/javacord/entities/message/Message.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/Message.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -837,6 +838,19 @@ public interface Message extends DiscordEntity, Comparable<Message> {
     }
 
     /**
+     * Gets messages before this message until one that meets the given condition is found.
+     * If no message matches the condition, an empty set is returned.
+     *
+     * @param condition The abort condition for when to stop retrieving messages.
+     * @return The messages.
+     * @see TextChannel#getMessagesBefore(int, long)
+     * @see #getMessagesBeforeAsStream()
+     */
+    default CompletableFuture<MessageSet> getMessagesBeforeUntil(Predicate<Message> condition) {
+        return getChannel().getMessagesBeforeUntil(condition, this);
+    }
+
+    /**
      * Gets a stream of messages before this message sorted from newest to oldest.
      * <p>
      * The messages are retrieved in batches synchronously from Discord,
@@ -860,6 +874,19 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      */
     default CompletableFuture<MessageSet> getMessagesAfter(int limit) {
         return getChannel().getMessagesAfter(limit, this);
+    }
+
+    /**
+     * Gets messages after this message until one that meets the given condition is found.
+     * If no message matches the condition, an empty set is returned.
+     *
+     * @param condition The abort condition for when to stop retrieving messages.
+     * @return The messages.
+     * @see TextChannel#getMessagesAfter(int, long)
+     * @see #getMessagesAfterAsStream()
+     */
+    default CompletableFuture<MessageSet> getMessagesAfterUntil(Predicate<Message> condition) {
+        return getChannel().getMessagesAfterUntil(condition, this);
     }
 
     /**
@@ -890,6 +917,24 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      */
     default CompletableFuture<MessageSet> getMessagesAround(int limit) {
         return getChannel().getMessagesAround(limit, this);
+    }
+
+    /**
+     * Gets messages around this message until one that meets the given condition is found.
+     * If no message matches the condition, an empty set is returned.
+     * This message will be part of the result in addition to the messages around and is matched against the condition
+     * and will abort retrieval.
+     * Half of the messages will be older than this message and half of the message will be newer.
+     * If there aren't enough older or newer messages, the actual amount of messages will be less than the given limit.
+     * It's also not guaranteed to be perfectly balanced.
+     *
+     * @param condition The abort condition for when to stop retrieving messages.
+     * @return The messages.
+     * @see TextChannel#getMessagesAround(int, long)
+     * @see #getMessagesAroundAsStream()
+     */
+    default CompletableFuture<MessageSet> getMessagesAroundUntil(Predicate<Message> condition) {
+        return getChannel().getMessagesAroundUntil(condition, this);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/message/MessageHistory.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/MessageHistory.java
@@ -36,7 +36,7 @@ public interface MessageHistory {
         if (getMessages().isEmpty()) {
             throw new IllegalStateException("Cannot get oldest message because the history does not contain messages!");
         }
-        return getMessages().get(getMessages().size() - 1);
+        return getMessages().get(0);
     }
 
     /**
@@ -49,7 +49,7 @@ public interface MessageHistory {
         if (getMessages().isEmpty()) {
             throw new IllegalStateException("Cannot get newest message because the history does not contain messages!");
         }
-        return getMessages().get(0);
+        return getMessages().get(getMessages().size() - 1);
     }
 
 }

--- a/src/main/java/de/btobastian/javacord/entities/message/MessageSet.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/MessageSet.java
@@ -6,7 +6,7 @@ import java.util.stream.Stream;
 /**
  * This class represents a history of messages in a specific channel.
  */
-public interface MessageHistory {
+public interface MessageSet {
 
     /**
      * Gets an ordered list with all messages.

--- a/src/main/java/de/btobastian/javacord/entities/message/MessageSet.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/MessageSet.java
@@ -1,55 +1,48 @@
 package de.btobastian.javacord.entities.message;
 
-import java.util.List;
-import java.util.stream.Stream;
+import java.util.NavigableSet;
+import java.util.Optional;
 
 /**
- * This class represents a history of messages in a specific channel.
+ * This class represents an unmodifiable set of messages that is always sorted from oldest
+ * to newest according to the natural ordering of {@link Message}s.
  */
-public interface MessageSet {
-
-    /**
-     * Gets an ordered list with all messages.
-     * The message with the lowest index is the newest message.
-     * The message with the largest index is the oldest message.
-     *
-     * @return An ordered list with all messages.
-     */
-    List<Message> getMessages();
-
-    /**
-     * Gets a stream with all messages in the history.
-     *
-     * @return A stream with all messages in the history.
-     */
-    default Stream<Message> stream() {
-        return getMessages().stream();
-    }
+public interface MessageSet extends NavigableSet<Message> {
 
     /**
      * Gets the oldest message in the history.
      *
      * @return The oldest message in the history.
-     * @throws IllegalStateException If the messages list is empty.
      */
-    default Message getOldestMessage() throws IllegalStateException {
-        if (getMessages().isEmpty()) {
-            throw new IllegalStateException("Cannot get oldest message because the history does not contain messages!");
-        }
-        return getMessages().get(0);
+    default Optional<Message> getOldestMessage() {
+        return isEmpty() ? Optional.empty() : Optional.of(first());
     }
 
     /**
      * Gets the newest message in the history.
      *
      * @return The newest message in the history.
-     * @throws IllegalStateException If the messages list is empty.
      */
-    default Message getNewestMessage() throws IllegalStateException {
-        if (getMessages().isEmpty()) {
-            throw new IllegalStateException("Cannot get newest message because the history does not contain messages!");
-        }
-        return getMessages().get(getMessages().size() - 1);
+    default Optional<Message> getNewestMessage() {
+        return isEmpty() ? Optional.empty() : Optional.of(last());
     }
+
+    @Override
+    MessageSet subSet(Message fromElement, boolean fromInclusive, Message toElement, boolean toInclusive);
+
+    @Override
+    MessageSet headSet(Message toElement, boolean inclusive);
+
+    @Override
+    MessageSet tailSet(Message fromElement, boolean inclusive);
+
+    @Override
+    MessageSet subSet(Message fromElement, Message toElement);
+
+    @Override
+    MessageSet headSet(Message toElement);
+
+    @Override
+    MessageSet tailSet(Message fromElement);
 
 }

--- a/src/main/java/de/btobastian/javacord/entities/message/impl/ImplMessage.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/impl/ImplMessage.java
@@ -297,7 +297,7 @@ public class ImplMessage implements Message {
 
     @Override
     public int compareTo(Message otherMessage) {
-        return otherMessage.getCreationTimestamp().compareTo(getCreationTimestamp());
+        return Long.compareUnsigned(getId(), otherMessage.getId());
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/entities/message/impl/ImplMessageSet.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/impl/ImplMessageSet.java
@@ -1,7 +1,7 @@
 package de.btobastian.javacord.entities.message.impl;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import de.btobastian.javacord.ImplDiscordApi;
+import de.btobastian.javacord.entities.DiscordEntity;
 import de.btobastian.javacord.entities.channels.TextChannel;
 import de.btobastian.javacord.entities.message.Message;
 import de.btobastian.javacord.entities.message.MessageSet;
@@ -13,8 +13,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
+import java.util.NavigableSet;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * The implementation of {@link MessageSet}.
@@ -22,71 +29,86 @@ import java.util.concurrent.CompletableFuture;
 public class ImplMessageSet implements MessageSet {
 
     /**
-     * A list with all messages.
+     * A read-only navigable set with all messages to let the JDK do the dirty work.
      */
-    private final List<Message> messages = new ArrayList<>();
+    private final NavigableSet<Message> messages;
 
     /**
-     * The text channel of the messages.
-     */
-    private final TextChannel channel;
-
-    /**
-     * Creates a new message history.
+     * Creates a new message set.
      *
-     * @param channel The channel of the messages.
+     * @param messages The messages to be contained in this set.
      */
-    private ImplMessageSet(TextChannel channel) {
-        this.channel = channel;
+    public ImplMessageSet(NavigableSet<Message> messages) {
+        this.messages = Collections.unmodifiableNavigableSet(messages);
     }
 
     /**
-     * Gets the history of messages in the given channel.
+     * Creates a new message set.
+     *
+     * @param messages The messages to be contained in this set.
+     */
+    public ImplMessageSet(Collection<Message> messages) {
+        this(new TreeSet<>(messages));
+    }
+
+    /**
+     * Creates a new message set.
+     *
+     * @param messages The messages to be contained in this set.
+     */
+    public ImplMessageSet(Message... messages) {
+        this(Arrays.asList(messages));
+    }
+
+    /**
+     * Gets up to a given amount of messages in the given channel from the newer end.
      *
      * @param channel The channel of the messages.
      * @param limit The limit of messages to get.
-     * @return The history.
+     * @return The messages.
      */
-    public static CompletableFuture<MessageSet> getHistory(TextChannel channel, int limit) {
-        return getHistory(channel, limit, -1, -1);
+    public static CompletableFuture<MessageSet> getMessages(TextChannel channel, int limit) {
+        return getMessages(channel, limit, -1, -1);
     }
 
     /**
-     * Gets the history of messages before a given message in the given channel.
+     * Gets up to a given amount of messages in the given channel before a given message in any channel.
      *
      * @param channel The channel of the messages.
      * @param limit The limit of messages to get.
      * @param before Get messages before the message with this id.
-     * @return The history.
+     * @return The messages.
      */
-    public static CompletableFuture<MessageSet> getHistoryBefore(TextChannel channel, int limit, long before) {
-        return getHistory(channel, limit, before, -1);
+    public static CompletableFuture<MessageSet> getMessagesBefore(TextChannel channel, int limit, long before) {
+        return getMessages(channel, limit, before, -1);
     }
 
     /**
-     * Gets the history of messages after a given message in the given channel.
+     * Gets up to a given amount of messages in the given channel after a given message in any channel.
      *
      * @param channel The channel of the messages.
      * @param limit The limit of messages to get.
      * @param after Get messages after the message with this id.
-     * @return The history.
+     * @return The messages.
      */
-    public static CompletableFuture<MessageSet> getHistoryAfter(TextChannel channel, int limit, long after) {
-        return getHistory(channel, limit, -1, after);
+    public static CompletableFuture<MessageSet> getMessagesAfter(TextChannel channel, int limit, long after) {
+        return getMessages(channel, limit, -1, after);
     }
 
     /**
-     * Gets the history of messages around a given message in the given channel.
-     * Half of the message will be older than the given message and half of the message will be newer.
+     * Gets up to a given amount of messages in the given channel around a given message in any channel.
+     * The given message will be part of the result in addition to the messages around if it was sent in the given
+     * channel and does not count towards the limit.
+     * Half of the messages will be older than the given message and half of the messages will be newer.
      * If there aren't enough older or newer messages, the actual amount of messages will be less than the given limit.
      * It's also not guaranteed to be perfectly balanced.
      *
      * @param channel The channel of the messages.
      * @param limit The limit of messages to get.
      * @param around Get messages around the message with this id.
-     * @return The history.
+     * @return The messages.
      */
-    public static CompletableFuture<MessageSet> getHistoryAround(TextChannel channel, int limit, long around) {
+    public static CompletableFuture<MessageSet> getMessagesAround(TextChannel channel, int limit, long around) {
         CompletableFuture<MessageSet> future = new CompletableFuture<>();
         channel.getApi().getThreadPool().getExecutorService().submit(() -> {
             try {
@@ -94,20 +116,30 @@ public class ImplMessageSet implements MessageSet {
                 int halfLimit = limit / 2;
 
                 // get the newer half
-                ImplMessageSet history = (ImplMessageSet) getHistoryAfter(channel, halfLimit, around).join();
-
-                // calculate the message id for getting the older half + around message
-                long referenceMessageId = (history.getMessages().size() == 0) ? -1 : history.getOldestMessage().getId();
+                MessageSet newerMessages = getMessagesAfter(channel, halfLimit, around).join();
 
                 // get the older half + around message
-                MessageSet historyBefore = getHistoryBefore(channel, halfLimit + 1, referenceMessageId).join();
+                MessageSet olderMessages = getMessagesBefore(channel, halfLimit + 1, around + 1).join();
 
-                // combine the messages of these "histories"
-                history.messages.addAll(((ImplMessageSet) historyBefore).messages);
-                history.messages.sort(null);
+                // remove the oldest message if the around message is not part of the result while there is a result,
+                // for example because the around message was from a different channel
+                if (olderMessages.getNewestMessage()
+                        .map(DiscordEntity::getId)
+                        .map(id -> id != around)
+                        .orElse(false)) {
+                    olderMessages = olderMessages.tailSet(
+                            olderMessages.getOldestMessage().orElseThrow(AssertionError::new),
+                            false);
+                }
+
+                // combine the messages into one collection
+                Collection<Message> messages = Stream
+                        .of(olderMessages, newerMessages)
+                        .flatMap(Collection::stream)
+                        .collect(Collectors.toList());
 
                 // we are done
-                future.complete(history);
+                future.complete(new ImplMessageSet(messages));
             } catch (Throwable t) {
                 future.completeExceptionally(t);
             }
@@ -116,61 +148,66 @@ public class ImplMessageSet implements MessageSet {
     }
 
     /**
-     * Gets the history of messages in the given channel.
+     * Gets up to a given amount of messages in the given channel.
      *
      * @param channel The channel of the messages.
      * @param limit The limit of messages to get.
      * @param before Get messages before the message with this id.
      * @param after Get messages after the message with this id.
      *
-     * @return The history.
+     * @return The messages.
      */
-    private static CompletableFuture<MessageSet> getHistory(
-            TextChannel channel, int limit, long before, long after) {
+    private static CompletableFuture<MessageSet> getMessages(TextChannel channel, int limit, long before, long after) {
         CompletableFuture<MessageSet> future = new CompletableFuture<>();
         channel.getApi().getThreadPool().getExecutorService().submit(() -> {
             try {
-                ImplMessageSet history = new ImplMessageSet(channel);
-
                 // get the initial batch with the first <= 100 messages
                 int initialBatchSize = ((limit % 100) == 0) ? 100 : limit % 100;
-                Message[] msgArray = history.request(initialBatchSize, before, after, -1).join();
-                history.messages.addAll(Arrays.asList(msgArray));
-                history.messages.sort(null);
+                MessageSet initialMessages = request(channel, initialBatchSize, before, after).join();
 
                 // limit <= 100 => initial request got all messages
-                // msgArray is empty => READ_MESSAGE_HISTORY permission is denied or no more messages available
-                if ((limit <= 100) || (msgArray.length == 0)) {
-                    future.complete(history);
+                // initialMessages is empty => READ_MESSAGE_HISTORY permission is denied or no more messages available
+                if ((limit <= 100) || initialMessages.isEmpty()) {
+                    future.complete(initialMessages);
                     return;
                 }
 
-                // calculate the amount of remaining message to get
+                // calculate the amount and direction of remaining message to get
                 // this will be a multiple of 100 and at least 100
                 int remainingMessages = limit - initialBatchSize;
+                int steps = remainingMessages / 100;
+                // "before" is set or both are not set
+                boolean older = (before != -1) || (after == -1);
+                boolean newer = after != -1;
 
                 // get remaining messages
-                for (int step = 0; step < remainingMessages / 100; ++step) {
-                    msgArray = history.request(
-                            100,
-                            // before was set or both were not set
-                            (before != -1) || (after == -1) ? history.getOldestMessage().getId() : -1,
-                            (after != -1) ? history.getNewestMessage().getId() : -1,
-                            -1
-                    ).join();
+                List<MessageSet> messageSets = new ArrayList<>();
+                MessageSet lastMessages = initialMessages;
+                messageSets.add(lastMessages);
+                for (int step = 0; step < steps; ++step) {
+                    lastMessages = request(channel,
+                                           100,
+                                           lastMessages.getOldestMessage()
+                                                   .filter(message -> older)
+                                                   .map(DiscordEntity::getId)
+                                                   .orElse(-1L),
+                                           lastMessages.getNewestMessage()
+                                                   .filter(message -> newer)
+                                                   .map(DiscordEntity::getId)
+                                                   .orElse(-1L)).join();
 
                     // no more messages available
-                    if (msgArray.length == 0) {
+                    if (lastMessages.isEmpty()) {
                         break;
                     }
 
-                    // combine the messages of these "histories"
-                    history.messages.addAll(Arrays.asList(msgArray));
-                    history.messages.sort(null);
+                    messageSets.add(lastMessages);
                 }
 
-                // we are done
-                future.complete(history);
+                // combine the message sets
+                future.complete(new ImplMessageSet(messageSets.stream()
+                                                           .flatMap(Collection::stream)
+                                                           .collect(Collectors.toList())));
             } catch (Throwable t) {
                 future.completeExceptionally(t);
             }
@@ -181,15 +218,15 @@ public class ImplMessageSet implements MessageSet {
     /**
      * Requests the messages from Discord.
      *
+     * @param channel The channel of which to get messages from.
      * @param limit The limit of messages to get.
      * @param before Get messages before the message with this id.
      * @param after Get messages after the message with this id.
-     * @param around Get messages around the message with this id.
      * @return A future to check if the request was successful.
      */
-    private CompletableFuture<Message[]> request(int limit, long before, long after, long around) {
-        RestRequest<Message[]> restRequest =
-                new RestRequest<Message[]>(channel.getApi(), RestMethod.GET, RestEndpoint.MESSAGE)
+    private static CompletableFuture<MessageSet> request(TextChannel channel, int limit, long before, long after) {
+        RestRequest<MessageSet> restRequest =
+                new RestRequest<MessageSet>(channel.getApi(), RestMethod.GET, RestEndpoint.MESSAGE)
                 .setUrlParameters(String.valueOf(channel.getId()));
 
         if (limit != -1) {
@@ -201,21 +238,163 @@ public class ImplMessageSet implements MessageSet {
         if (after != -1) {
             restRequest.addQueryParameter("after", String.valueOf(after));
         }
-        if (around != -1) {
-            restRequest.addQueryParameter("around", String.valueOf(around));
-        }
 
         return restRequest.execute(result -> {
-            Collection<Message> messages = new ArrayList<>();
-            for (JsonNode messageJson : result.getJsonBody()) {
-                messages.add(((ImplDiscordApi) channel.getApi()).getOrCreateMessage(channel, messageJson));
-            }
-            return messages.toArray(new Message[messages.size()]);
+            Collection<Message> messages = StreamSupport.stream(result.getJsonBody().spliterator(), false)
+                    .map(messageJson -> ((ImplDiscordApi) channel.getApi()).getOrCreateMessage(channel, messageJson))
+                    .collect(Collectors.toList());
+            return new ImplMessageSet(messages);
         });
     }
 
     @Override
-    public List<Message> getMessages() {
-        return Collections.unmodifiableList(messages);
+    public Message lower(Message message) {
+        return messages.lower(message);
     }
+
+    @Override
+    public Message floor(Message message) {
+        return messages.floor(message);
+    }
+
+    @Override
+    public Message ceiling(Message message) {
+        return messages.ceiling(message);
+    }
+
+    @Override
+    public Message higher(Message message) {
+        return messages.higher(message);
+    }
+
+    @Override
+    public Message pollFirst() {
+        return messages.pollFirst();
+    }
+
+    @Override
+    public Message pollLast() {
+        return messages.pollLast();
+    }
+
+    @Override
+    public int size() {
+        return messages.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return messages.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return messages.contains(o);
+    }
+
+    @Override
+    public Iterator<Message> iterator() {
+        return messages.iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return messages.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return messages.toArray(a);
+    }
+
+    @Override
+    public boolean add(Message message) {
+        return messages.add(message);
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return messages.remove(o);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return messages.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends Message> c) {
+        return messages.addAll(c);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        return messages.retainAll(c);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        return messages.removeAll(c);
+    }
+
+    @Override
+    public void clear() {
+        messages.clear();
+    }
+
+    @Override
+    public NavigableSet<Message> descendingSet() {
+        return messages.descendingSet();
+    }
+
+    @Override
+    public Iterator<Message> descendingIterator() {
+        return messages.descendingIterator();
+    }
+
+    @Override
+    public MessageSet subSet(Message fromElement, boolean fromInclusive, Message toElement, boolean toInclusive) {
+        return new ImplMessageSet(messages.subSet(fromElement, fromInclusive, toElement, toInclusive));
+    }
+
+    @Override
+    public MessageSet headSet(Message toElement, boolean inclusive) {
+        return new ImplMessageSet(messages.headSet(toElement, inclusive));
+    }
+
+    @Override
+    public MessageSet tailSet(Message fromElement, boolean inclusive) {
+        return new ImplMessageSet(messages.tailSet(fromElement, inclusive));
+    }
+
+    @Override
+    public Comparator<? super Message> comparator() {
+        return messages.comparator();
+    }
+
+    @Override
+    public MessageSet subSet(Message fromElement, Message toElement) {
+        return new ImplMessageSet(messages.subSet(fromElement, toElement));
+    }
+
+    @Override
+    public MessageSet headSet(Message toElement) {
+        return new ImplMessageSet(messages.headSet(toElement));
+    }
+
+    @Override
+    public MessageSet tailSet(Message fromElement) {
+        return new ImplMessageSet(messages.tailSet(fromElement));
+    }
+
+    @Override
+    public Message first() {
+        return messages.first();
+    }
+
+    @Override
+    public Message last() {
+        return messages.last();
+    }
+
 }

--- a/src/main/java/de/btobastian/javacord/entities/message/impl/ImplMessageSet.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/impl/ImplMessageSet.java
@@ -1,5 +1,6 @@
 package de.btobastian.javacord.entities.message.impl;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entities.DiscordEntity;
 import de.btobastian.javacord.entities.channels.TextChannel;
@@ -17,8 +18,11 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NavigableSet;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -66,9 +70,24 @@ public class ImplMessageSet implements MessageSet {
      * @param channel The channel of the messages.
      * @param limit The limit of messages to get.
      * @return The messages.
+     * @see #getMessagesAsStream(TextChannel)
      */
     public static CompletableFuture<MessageSet> getMessages(TextChannel channel, int limit) {
         return getMessages(channel, limit, -1, -1);
+    }
+
+    /**
+     * Gets a stream of messages in the given channel sorted from newest to oldest.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @param channel The channel of the messages.
+     * @return The stream.
+     * @see #getMessages(TextChannel, int)
+     */
+    public static Stream<Message> getMessagesAsStream(TextChannel channel) {
+        return getMessagesAsStream(channel, -1, -1);
     }
 
     /**
@@ -78,9 +97,26 @@ public class ImplMessageSet implements MessageSet {
      * @param limit The limit of messages to get.
      * @param before Get messages before the message with this id.
      * @return The messages.
+     * @see #getMessagesBeforeAsStream(TextChannel, long)
      */
     public static CompletableFuture<MessageSet> getMessagesBefore(TextChannel channel, int limit, long before) {
         return getMessages(channel, limit, before, -1);
+    }
+
+    /**
+     * Gets a stream of messages in the given channel before a given message in any channel sorted from newest to
+     * oldest.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @param channel The channel of the messages.
+     * @param before Get messages before the message with this id.
+     * @return The stream.
+     * @see #getMessagesBefore(TextChannel, int, long)
+     */
+    public static Stream<Message> getMessagesBeforeAsStream(TextChannel channel, long before) {
+        return getMessagesAsStream(channel, before, -1);
     }
 
     /**
@@ -90,9 +126,25 @@ public class ImplMessageSet implements MessageSet {
      * @param limit The limit of messages to get.
      * @param after Get messages after the message with this id.
      * @return The messages.
+     * @see #getMessagesAfterAsStream(TextChannel, long)
      */
     public static CompletableFuture<MessageSet> getMessagesAfter(TextChannel channel, int limit, long after) {
         return getMessages(channel, limit, -1, after);
+    }
+
+    /**
+     * Gets a stream of messages in the given channel after a given message in any channel sorted from oldest to newest.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @param channel The channel of the messages.
+     * @param after Get messages after the message with this id.
+     * @return The stream.
+     * @see #getMessagesAfter(TextChannel, int, long)
+     */
+    public static Stream<Message> getMessagesAfterAsStream(TextChannel channel, long after) {
+        return getMessagesAsStream(channel, -1, after);
     }
 
     /**
@@ -107,6 +159,7 @@ public class ImplMessageSet implements MessageSet {
      * @param limit The limit of messages to get.
      * @param around Get messages around the message with this id.
      * @return The messages.
+     * @see #getMessagesAroundAsStream(TextChannel, long)
      */
     public static CompletableFuture<MessageSet> getMessagesAround(TextChannel channel, int limit, long around) {
         CompletableFuture<MessageSet> future = new CompletableFuture<>();
@@ -148,6 +201,97 @@ public class ImplMessageSet implements MessageSet {
     }
 
     /**
+     * Gets a stream of messages in the given channel around a given message in any channel.
+     * The first message in the stream will be the given message if it was sent in the given channel.
+     * After that you will always get an older message and a newer message alternating as long as on both sides
+     * messages are available. If only on one side further messages are available, only those are delivered further on.
+     * It's not guaranteed to be perfectly balanced.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @param channel The channel of the messages.
+     * @param around Get messages around the message with this id.
+     * @return The stream.
+     * @see #getMessagesAround(TextChannel, int, long)
+     */
+    public static Stream<Message> getMessagesAroundAsStream(TextChannel channel, long around) {
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(new Iterator<Message>() {
+            private final ImplDiscordApi api = ((ImplDiscordApi) channel.getApi());
+            private final AtomicBoolean firstBatch = new AtomicBoolean(true);
+            private final AtomicBoolean nextIsOlder = new AtomicBoolean();
+            private long olderReferenceMessageId = around;
+            private long newerReferenceMessageId = around - 1;
+            private final List<JsonNode> olderMessageJsons = Collections.synchronizedList(new ArrayList<>());
+            private final List<JsonNode> newerMessageJsons = Collections.synchronizedList(new ArrayList<>());
+            private final AtomicBoolean hasMoreOlderMessages = new AtomicBoolean(true);
+            private final AtomicBoolean hasMoreNewerMessages = new AtomicBoolean(true);
+
+            private void ensureMessagesAvailable() {
+                if (olderMessageJsons.isEmpty() && hasMoreOlderMessages.get()) {
+                    synchronized (olderMessageJsons) {
+                        if (olderMessageJsons.isEmpty() && hasMoreOlderMessages.get()) {
+                            olderMessageJsons.addAll(requestAsSortedJsonNodes(
+                                    channel,
+                                    100,
+                                    olderReferenceMessageId,
+                                    -1,
+                                    true
+                            ));
+                            if (olderMessageJsons.isEmpty()) {
+                                hasMoreOlderMessages.set(false);
+                            } else {
+                                olderReferenceMessageId =
+                                        olderMessageJsons.get(olderMessageJsons.size() - 1).get("id").asLong();
+                            }
+                        }
+                    }
+                }
+                if (newerMessageJsons.isEmpty() && hasMoreNewerMessages.get()) {
+                    synchronized (newerMessageJsons) {
+                        if (newerMessageJsons.isEmpty() && hasMoreNewerMessages.get()) {
+                            newerMessageJsons.addAll(requestAsSortedJsonNodes(
+                                    channel,
+                                    100,
+                                    -1,
+                                    newerReferenceMessageId,
+                                    false
+                            ));
+                            if (newerMessageJsons.isEmpty()) {
+                                hasMoreNewerMessages.set(false);
+                            } else {
+                                newerReferenceMessageId =
+                                        newerMessageJsons.get(newerMessageJsons.size() - 1).get("id").asLong();
+                                if (firstBatch.getAndSet(false)) {
+                                    nextIsOlder.set(newerMessageJsons.get(0).get("id").asLong() != around);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public boolean hasNext() {
+                ensureMessagesAvailable();
+                return !(olderMessageJsons.isEmpty() && newerMessageJsons.isEmpty());
+            }
+
+            @Override
+            public Message next() {
+                ensureMessagesAvailable();
+                boolean nextIsOlder = this.nextIsOlder.get();
+                this.nextIsOlder.set(!nextIsOlder);
+                JsonNode messageJson =
+                        ((nextIsOlder && !olderMessageJsons.isEmpty()) || newerMessageJsons.isEmpty())
+                        ? olderMessageJsons.remove(0)
+                        : newerMessageJsons.remove(0);
+                return api.getOrCreateMessage(channel, messageJson);
+            }
+        }, Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.NONNULL | Spliterator.CONCURRENT), false);
+    }
+
+    /**
      * Gets up to a given amount of messages in the given channel.
      *
      * @param channel The channel of the messages.
@@ -156,6 +300,7 @@ public class ImplMessageSet implements MessageSet {
      * @param after Get messages after the message with this id.
      *
      * @return The messages.
+     * @see #getMessagesAsStream(TextChannel, long, long)
      */
     private static CompletableFuture<MessageSet> getMessages(TextChannel channel, int limit, long before, long after) {
         CompletableFuture<MessageSet> future = new CompletableFuture<>();
@@ -163,7 +308,7 @@ public class ImplMessageSet implements MessageSet {
             try {
                 // get the initial batch with the first <= 100 messages
                 int initialBatchSize = ((limit % 100) == 0) ? 100 : limit % 100;
-                MessageSet initialMessages = request(channel, initialBatchSize, before, after).join();
+                MessageSet initialMessages = requestAsMessages(channel, initialBatchSize, before, after);
 
                 // limit <= 100 => initial request got all messages
                 // initialMessages is empty => READ_MESSAGE_HISTORY permission is denied or no more messages available
@@ -185,16 +330,16 @@ public class ImplMessageSet implements MessageSet {
                 MessageSet lastMessages = initialMessages;
                 messageSets.add(lastMessages);
                 for (int step = 0; step < steps; ++step) {
-                    lastMessages = request(channel,
-                                           100,
-                                           lastMessages.getOldestMessage()
-                                                   .filter(message -> older)
-                                                   .map(DiscordEntity::getId)
-                                                   .orElse(-1L),
-                                           lastMessages.getNewestMessage()
-                                                   .filter(message -> newer)
-                                                   .map(DiscordEntity::getId)
-                                                   .orElse(-1L)).join();
+                    lastMessages = requestAsMessages(channel,
+                                                     100,
+                                                     lastMessages.getOldestMessage()
+                                                             .filter(message -> older)
+                                                             .map(DiscordEntity::getId)
+                                                             .orElse(-1L),
+                                                     lastMessages.getNewestMessage()
+                                                             .filter(message -> newer)
+                                                             .map(DiscordEntity::getId)
+                                                             .orElse(-1L));
 
                     // no more messages available
                     if (lastMessages.isEmpty()) {
@@ -216,17 +361,107 @@ public class ImplMessageSet implements MessageSet {
     }
 
     /**
+     * Gets a stream of messages in the given channel sorted from newest to oldest.
+     * <p>
+     * The messages are retrieved in batches synchronously from Discord,
+     * so consider not using this method from a listener directly.
+     *
+     * @param channel The channel of the messages.
+     * @param before Get messages before the message with this id.
+     * @param after Get messages after the message with this id.
+     *
+     * @return The stream.
+     * @see #getMessages(TextChannel, int, long, long)
+     */
+    private static Stream<Message> getMessagesAsStream(TextChannel channel, long before, long after) {
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(new Iterator<Message>() {
+            private final ImplDiscordApi api = ((ImplDiscordApi) channel.getApi());
+            // before was set or both were not set
+            private final boolean older = (before != -1) || (after == -1);
+            private final boolean newer = after != -1;
+            private long referenceMessageId = older ? before : after;
+            private final List<JsonNode> messageJsons = Collections.synchronizedList(new ArrayList<>());
+
+            private void ensureMessagesAvailable() {
+                if (messageJsons.isEmpty()) {
+                    synchronized (messageJsons) {
+                        if (messageJsons.isEmpty()) {
+                            messageJsons.addAll(requestAsSortedJsonNodes(
+                                    channel,
+                                    100,
+                                    older ? referenceMessageId : -1,
+                                    newer ? referenceMessageId : -1,
+                                    older
+                            ));
+                            if (!messageJsons.isEmpty()) {
+                                referenceMessageId = messageJsons.get(messageJsons.size() - 1).get("id").asLong();
+                            }
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public boolean hasNext() {
+                ensureMessagesAvailable();
+                return !messageJsons.isEmpty();
+            }
+
+            @Override
+            public Message next() {
+                ensureMessagesAvailable();
+                return api.getOrCreateMessage(channel, messageJsons.remove(0));
+            }
+        }, Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.NONNULL | Spliterator.CONCURRENT), false);
+    }
+
+    /**
      * Requests the messages from Discord.
      *
      * @param channel The channel of which to get messages from.
      * @param limit The limit of messages to get.
      * @param before Get messages before the message with this id.
      * @param after Get messages after the message with this id.
-     * @return A future to check if the request was successful.
+     * @return The messages.
      */
-    private static CompletableFuture<MessageSet> request(TextChannel channel, int limit, long before, long after) {
-        RestRequest<MessageSet> restRequest =
-                new RestRequest<MessageSet>(channel.getApi(), RestMethod.GET, RestEndpoint.MESSAGE)
+    private static MessageSet requestAsMessages(TextChannel channel, int limit, long before, long after) {
+        ImplDiscordApi api = (ImplDiscordApi) channel.getApi();
+        return new ImplMessageSet(
+                requestAsJsonNodes(channel, limit, before, after).stream()
+                        .map(jsonNode -> api.getOrCreateMessage(channel, jsonNode))
+                        .collect(Collectors.toList()));
+    }
+
+    /**
+     * Requests the messages from Discord, sorted by their id.
+     *
+     * @param channel The channel of which to get messages from.
+     * @param limit The limit of messages to get.
+     * @param before Get messages before the message with this id.
+     * @param after Get messages after the message with this id.
+     * @param reversed If {@code true}, get from oldest to newest, otherwise from newest to oldest.
+     * @return The JSON nodes.
+     */
+    private static List<JsonNode> requestAsSortedJsonNodes(
+            TextChannel channel, int limit, long before, long after, boolean reversed) {
+        List<JsonNode> messageJsonNodes = requestAsJsonNodes(channel, limit, before, after);
+        Comparator<JsonNode> idComparator = Comparator.comparingLong(jsonNode -> jsonNode.get("id").asLong());
+        messageJsonNodes.sort(reversed ? idComparator.reversed() : idComparator);
+        return messageJsonNodes;
+    }
+
+    /**
+     * Requests the messages from Discord.
+     *
+     * @param channel The channel of which to get messages from.
+     * @param limit The limit of messages to get.
+     * @param before Get messages before the message with this id.
+     * @param after Get messages after the message with this id.
+     * @return The JSON nodes.
+     */
+    private static List<JsonNode> requestAsJsonNodes(TextChannel channel, int limit, long before, long after) {
+        RestRequest<List<JsonNode>> restRequest =
+                new RestRequest<List<JsonNode>>(channel.getApi(), RestMethod.GET, RestEndpoint.MESSAGE)
                 .setUrlParameters(String.valueOf(channel.getId()));
 
         if (limit != -1) {
@@ -240,11 +475,10 @@ public class ImplMessageSet implements MessageSet {
         }
 
         return restRequest.execute(result -> {
-            Collection<Message> messages = StreamSupport.stream(result.getJsonBody().spliterator(), false)
-                    .map(messageJson -> ((ImplDiscordApi) channel.getApi()).getOrCreateMessage(channel, messageJson))
-                    .collect(Collectors.toList());
-            return new ImplMessageSet(messages);
-        });
+            List<JsonNode> messageJsonNodes = new ArrayList<>();
+            result.getJsonBody().iterator().forEachRemaining(messageJsonNodes::add);
+            return messageJsonNodes;
+        }).join();
     }
 
     @Override


### PR DESCRIPTION
- Fix message history retrieval
- Fix the natural order, compareTo / equals consistency and comparison performance of Message
- Rename MessageHistory to MessageSet
- Make MessageSet implement NavigableSet<Message>
- Make DiscordApi#getCachedMessages() return MessageSet instead of Collection<Message>
- Make TextChannel#getPins() return MessageSet instead of List<Message>
- Add ...AsStream variants for the Message#getMessages..., TextChannel#getMessages... and ImplMessageSet.getMessages... methods