### PR TITLE
Listener Management Improvements

### DIFF
--- a/src/main/java/de/btobastian/javacord/DiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/DiscordApi.java
@@ -71,6 +71,7 @@ import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeManagedListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeMentionableListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeNameListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleCreateListener;
@@ -2012,6 +2013,21 @@ public interface DiscordApi {
      * @return A list with all registered role change mentionable listeners.
      */
     List<RoleChangeMentionableListener> getRoleChangeMentionableListeners();
+
+    /**
+     * Adds a listener, which listens to role name changes.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<RoleChangeNameListener> addRoleChangeNameListener(RoleChangeNameListener listener);
+
+    /**
+     * Gets a list with all registered role change name listeners.
+     *
+     * @return A list with all registered role change name listeners.
+     */
+    List<RoleChangeNameListener> getRoleChangeNameListeners();
 
     /**
      * Adds a listener, which listens to role permission changes.

--- a/src/main/java/de/btobastian/javacord/DiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/DiscordApi.java
@@ -28,14 +28,12 @@ import de.btobastian.javacord.entities.message.emoji.CustomEmoji;
 import de.btobastian.javacord.entities.permissions.Permissions;
 import de.btobastian.javacord.entities.permissions.Role;
 import de.btobastian.javacord.listeners.GloballyAttachableListener;
-import de.btobastian.javacord.listeners.ObjectAttachableListener;
 import de.btobastian.javacord.listeners.connection.LostConnectionListener;
 import de.btobastian.javacord.listeners.connection.ReconnectListener;
 import de.btobastian.javacord.listeners.connection.ResumeListener;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelChangeNameListener;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelCreateListener;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelDeleteListener;
-import de.btobastian.javacord.listeners.message.MessageAttachableListener;
 import de.btobastian.javacord.listeners.message.MessageCreateListener;
 import de.btobastian.javacord.listeners.message.MessageDeleteListener;
 import de.btobastian.javacord.listeners.message.MessageEditListener;
@@ -100,7 +98,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -1560,63 +1557,11 @@ public interface DiscordApi {
     ListenerManager<MessageDeleteListener> addMessageDeleteListener(MessageDeleteListener listener);
 
     /**
-     * Adds a listener, which listens to message deletions of a specific message.
-     *
-     * @param message The message which should be listened to.
-     * @param listener The listener to add.
-     * @return The manager of the listener.
-     */
-    default ListenerManager<MessageDeleteListener> addMessageDeleteListener(
-            Message message, MessageDeleteListener listener) {
-        return addMessageDeleteListener(message.getId(), listener);
-    }
-
-    /**
-     * Adds a listener, which listens to message deletions of a specific message.
-     *
-     * @param messageId The id of the message which should be listened to.
-     * @param listener The listener to add.
-     * @return The manager of the listener.
-     */
-    ListenerManager<MessageDeleteListener> addMessageDeleteListener(long messageId, MessageDeleteListener listener);
-
-    /**
      * Gets a list with all registered message delete listeners.
      *
      * @return A list with all registered message delete listeners.
      */
     List<MessageDeleteListener> getMessageDeleteListeners();
-
-    /**
-     * Gets a list with all registered message delete listeners of a specific message.
-     *
-     * @param message The message.
-     * @return A list with all registered message delete listeners.
-     */
-    default List<MessageDeleteListener> getMessageDeleteListeners(Message message) {
-        return getMessageDeleteListeners(message.getId());
-    }
-
-    /**
-     * Gets a list with all registered message delete listeners of a specific message.
-     *
-     * @param messageId The id of the message.
-     * @return A list with all registered message delete listeners.
-     */
-    List<MessageDeleteListener> getMessageDeleteListeners(long messageId);
-
-    /**
-     * Gets a list with all registered message delete listeners of a specific message.
-     *
-     * @param messageId The id of the message.
-     * @return A list with all registered message delete listeners.
-     */
-    default List<MessageDeleteListener> getMessageDeleteListeners(String messageId) {
-        try {
-            return getMessageDeleteListeners(Long.valueOf(messageId));
-        } catch (NumberFormatException ignored) { }
-        return Collections.emptyList();
-    }
 
     /**
      * Adds a listener, which listens to message edits.
@@ -1627,50 +1572,11 @@ public interface DiscordApi {
     ListenerManager<MessageEditListener> addMessageEditListener(MessageEditListener listener);
 
     /**
-     * Adds a listener, which listens to message edits of a specific message.
-     *
-     * @param message The message which should be listened to.
-     * @param listener The listener to add.
-     * @return The manager of the listener.
-     */
-    default ListenerManager<MessageEditListener> addMessageEditListener(
-            Message message, MessageEditListener listener) {
-        return addMessageEditListener(message.getId(), listener);
-    }
-
-    /**
-     * Adds a listener, which listens to message edits of a specific message.
-     *
-     * @param messageId The id of the message which should be listened to.
-     * @param listener The listener to add.
-     * @return The manager of the listener.
-     */
-    ListenerManager<MessageEditListener> addMessageEditListener(long messageId, MessageEditListener listener);
-
-    /**
      * Gets a list with all registered message edit listeners.
      *
      * @return A list with all registered message edit listeners.
      */
     List<MessageEditListener> getMessageEditListeners();
-
-    /**
-     * Gets a list with all registered message edit listeners of a specific message.
-     *
-     * @param message The message.
-     * @return A list with all registered message edit listeners.
-     */
-    default List<MessageEditListener> getMessageEditListeners(Message message) {
-        return getMessageEditListeners(message.getId());
-    }
-
-    /**
-     * Gets a list with all registered message edit listeners of a specific message.
-     *
-     * @param messageId The id of the message.
-     * @return A list with all registered message edit listeners.
-     */
-    List<MessageEditListener> getMessageEditListeners(long messageId);
 
     /**
      * Adds a listener, which listens to reactions being added.
@@ -1681,62 +1587,11 @@ public interface DiscordApi {
     ListenerManager<ReactionAddListener> addReactionAddListener(ReactionAddListener listener);
 
     /**
-     * Adds a listener, which listens to reactions being added to a specific message.
-     *
-     * @param message The message which should be listened to.
-     * @param listener The listener to add.
-     * @return The manager of the listener.
-     */
-    default ListenerManager<ReactionAddListener> addReactionAddListener(Message message, ReactionAddListener listener) {
-        return addReactionAddListener(message.getId(), listener);
-    }
-
-    /**
-     * Adds a listener, which listens to reactions being added to a specific message.
-     *
-     * @param messageId The id of the message which should be listened to.
-     * @param listener The listener to add.
-     * @return The manager of the listener.
-     */
-    ListenerManager<ReactionAddListener> addReactionAddListener(long messageId, ReactionAddListener listener);
-
-    /**
      * Gets a list with all registered reaction add listeners.
      *
      * @return A list with all registered reaction add listeners.
      */
     List<ReactionAddListener> getReactionAddListeners();
-
-    /**
-     * Gets a list with all registered reaction add listeners of a specific message.
-     *
-     * @param message The message.
-     * @return A list with all registered reaction add listeners.
-     */
-    default List<ReactionAddListener> getReactionAddListeners(Message message) {
-        return getReactionAddListeners(message.getId());
-    }
-
-    /**
-     * Gets a list with all registered reaction add listeners of a specific message.
-     *
-     * @param messageId The id of the message.
-     * @return A list with all registered reaction add listeners.
-     */
-    List<ReactionAddListener> getReactionAddListeners(long messageId);
-
-    /**
-     * Gets a list with all registered reaction add listeners of a specific message.
-     *
-     * @param messageId The id of the message.
-     * @return A list with all registered reaction add listeners.
-     */
-    default List<ReactionAddListener> getReactionAddListeners(String messageId) {
-        try {
-            return getReactionAddListeners(Long.valueOf(messageId));
-        } catch (NumberFormatException ignored) { }
-        return Collections.emptyList();
-    }
 
     /**
      * Adds a listener, which listens to reactions being removed.
@@ -1747,63 +1602,11 @@ public interface DiscordApi {
     ListenerManager<ReactionRemoveListener> addReactionRemoveListener(ReactionRemoveListener listener);
 
     /**
-     * Adds a listener, which listens to reactions being removed from a specific message.
-     *
-     * @param message The message which should be listened to.
-     * @param listener The listener to add.
-     * @return The manager of the listener.
-     */
-    default ListenerManager<ReactionRemoveListener> addReactionRemoveListener(
-            Message message, ReactionRemoveListener listener) {
-        return addReactionRemoveListener(message.getId(), listener);
-    }
-
-    /**
-     * Adds a listener, which listens to reactions being removed from a specific message.
-     *
-     * @param messageId The id of the message which should be listened to.
-     * @param listener The listener to add.
-     * @return The manager of the listener.
-     */
-    ListenerManager<ReactionRemoveListener> addReactionRemoveListener(long messageId, ReactionRemoveListener listener);
-
-    /**
      * Gets a list with all registered reaction remove listeners.
      *
      * @return A list with all registered reaction remove listeners.
      */
     List<ReactionRemoveListener> getReactionRemoveListeners();
-
-    /**
-     * Gets a list with all registered reaction remove listeners of a specific message.
-     *
-     * @param message The message.
-     * @return A list with all registered reaction remove listeners.
-     */
-    default List<ReactionRemoveListener> getReactionRemoveListeners(Message message) {
-        return getReactionRemoveListeners(message.getId());
-    }
-
-    /**
-     * Gets a list with all registered reaction remove listeners of a specific message.
-     *
-     * @param messageId The id of the message.
-     * @return A list with all registered reaction remove listeners.
-     */
-    List<ReactionRemoveListener> getReactionRemoveListeners(long messageId);
-
-    /**
-     * Gets a list with all registered reaction remove listeners of a specific message.
-     *
-     * @param messageId The id of the message.
-     * @return A list with all registered reaction remove listeners.
-     */
-    default List<ReactionRemoveListener> getReactionRemoveListeners(String messageId) {
-        try {
-            return getReactionRemoveListeners(Long.valueOf(messageId));
-        } catch (NumberFormatException ignored) { }
-        return Collections.emptyList();
-    }
 
     /**
      * Adds a listener, which listens to all reactions being removed at once.
@@ -1814,63 +1617,11 @@ public interface DiscordApi {
     ListenerManager<ReactionRemoveAllListener> addReactionRemoveAllListener(ReactionRemoveAllListener listener);
 
     /**
-     * Adds a listener, which listens to all reactions being removed from a specific message at once.
-     *
-     * @param message The message which should be listened to.
-     * @param listener The listener to add.
-     * @return The manager of the listener.
-     */
-    default ListenerManager<ReactionRemoveAllListener> addReactionRemoveAllListener(
-            Message message, ReactionRemoveAllListener listener) {
-        return addReactionRemoveAllListener(message.getId(), listener);
-    }
-
-    /**
-     * Adds a listener, which listens to all reactions being removed from a specific message at once.
-     *
-     * @param messageId The id of the message which should be listened to.
-     * @param listener The listener to add.
-     * @return The manager of the listener.
-     */
-    ListenerManager<ReactionRemoveAllListener> addReactionRemoveAllListener(long messageId, ReactionRemoveAllListener listener);
-
-    /**
      * Gets a list with all registered reaction remove all listeners.
      *
      * @return A list with all registered reaction remove all listeners.
      */
     List<ReactionRemoveAllListener> getReactionRemoveAllListeners();
-
-    /**
-     * Gets a list with all registered reaction remove all listeners of a specific message.
-     *
-     * @param message The message.
-     * @return A list with all registered reaction remove all listeners.
-     */
-    default List<ReactionRemoveAllListener> getReactionRemoveAllListeners(Message message) {
-        return getReactionRemoveAllListeners(message.getId());
-    }
-
-    /**
-     * Gets a list with all registered reaction remove all listeners of a specific message.
-     *
-     * @param messageId The id of the message.
-     * @return A list with all registered reaction remove all listeners.
-     */
-    List<ReactionRemoveAllListener> getReactionRemoveAllListeners(long messageId);
-
-    /**
-     * Gets a list with all registered reaction remove all listeners of a specific message.
-     *
-     * @param messageId The id of the message.
-     * @return A list with all registered reaction remove all listeners.
-     */
-    default List<ReactionRemoveAllListener> getReactionRemoveAllListeners(String messageId) {
-        try {
-            return getReactionRemoveAllListeners(Long.valueOf(messageId));
-        } catch (NumberFormatException ignored) { }
-        return Collections.emptyList();
-    }
 
     /**
      * Adds a listener, which listens to users joining servers.
@@ -2475,114 +2226,5 @@ public interface DiscordApi {
      * their assigned listener classes they listen to.
      */
     <T extends GloballyAttachableListener> Map<T, List<Class<T>>> getListeners();
-
-    /**
-     * Adds a listener that implements one or more {@code MessageAttachableListener}s to the message with the given id.
-     * Adding a listener multiple times will only add it once
-     * and return the same listener managers on each invocation.
-     * The order of invocation is according to first addition.
-     *
-     * @param messageId The id of the message which should be listened to.
-     * @param listener The listener to add.
-     * @param <T> The type of the listener.
-     * @return The managers for the added listener.
-     */
-    <T extends MessageAttachableListener & ObjectAttachableListener> Collection<ListenerManager<T>>
-    addMessageAttachableListener(long messageId, T listener);
-
-    /**
-     * Adds a listener that implements one or more {@code MessageAttachableListener}s to the given message.
-     * Adding a listener multiple times will only add it once
-     * and return the same listener managers on each invocation.
-     * The order of invocation is according to first addition.
-     *
-     * @param message The message which should be listened to.
-     * @param listener The listener to add.
-     * @param <T> The type of the listener.
-     * @return The managers for the added listener.
-     */
-    default <T extends MessageAttachableListener & ObjectAttachableListener> Collection<ListenerManager<T>>
-    addMessageAttachableListener(Message message, T listener) {
-        return addMessageAttachableListener(message.getId(), listener);
-    }
-
-    /**
-     * Removes a {@code MessageAttachableListener} from the message with the given id.
-     *
-     * @param messageId The id of the message.
-     * @param listenerClass The listener class.
-     * @param listener The listener to remove.
-     * @param <T> The type of the listener.
-     */
-    <T extends MessageAttachableListener & ObjectAttachableListener> void removeMessageAttachableListener(
-            long messageId, Class<T> listenerClass, T listener);
-
-    /**
-     * Removes a listener that implements one or more {@code MessageAttachableListener}s from the given message.
-     *
-     * @param message The message.
-     * @param listenerClass The listener class.
-     * @param listener The listener to remove.
-     * @param <T> The type of the listener.
-     */
-    default <T extends MessageAttachableListener & ObjectAttachableListener> void removeMessageAttachableListener(
-            Message message, Class<T> listenerClass, T listener) {
-        removeMessageAttachableListener(message.getId(), listenerClass, listener);
-    }
-
-    /**
-     * Removes a listener that implements one or more {@code MessageAttachableListener}s from the message with the given id.
-     *
-     * @param messageId The id of the message.
-     * @param listener The listener to remove.
-     * @param <T> The type of the listener.
-     */
-    @SuppressWarnings("unchecked")
-    default <T extends MessageAttachableListener & ObjectAttachableListener> void removeMessageAttachableListener(
-            long messageId, T listener) {
-        ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(MessageAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .forEach(listenerClass -> removeMessageAttachableListener(messageId, listenerClass, listener));
-    }
-
-    /**
-     * Removes a listener that implements one or more {@code MessageAttachableListener}s from the given message.
-     *
-     * @param message The message.
-     * @param listener The listener to remove.
-     * @param <T> The type of the listener.
-     */
-    default <T extends MessageAttachableListener & ObjectAttachableListener> void removeMessageAttachableListener(
-            Message message, T listener) {
-        removeMessageAttachableListener(message.getId(), listener);
-    }
-
-    /**
-     * Gets a map with all registered listeners that implement one or more {@code MessageAttachableListener}s and their
-     * assigned listener classes they listen to for the message with the given id.
-     *
-     * @param messageId The id of the message.
-     * @param <T> The type of the listeners.
-     * @return A map with all registered listeners that implement one or more {@code MessageAttachableListener}s and
-     * their assigned listener classes they listen to.
-     */
-    <T extends MessageAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
-    getMessageAttachableListeners(long messageId);
-
-    /**
-     * Gets a map with all registered listeners that implement one or more {@code MessageAttachableListener}s and their
-     * assigned listener classes they listen to for the given message.
-     *
-     * @param message The message.
-     * @param <T> The type of the listeners.
-     * @return A map with all registered listeners that implement one or more {@code MessageAttachableListener}s and
-     * their assigned listener classes they listen to.
-     */
-    default <T extends MessageAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
-    getMessageAttachableListeners(Message message) {
-        return getMessageAttachableListeners(message.getId());
-    }
 
 }

--- a/src/main/java/de/btobastian/javacord/DiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/DiscordApi.java
@@ -68,6 +68,7 @@ import de.btobastian.javacord.listeners.server.member.ServerMemberJoinListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberLeaveListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberUnbanListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleCreateListener;
@@ -1963,6 +1964,21 @@ public interface DiscordApi {
      * @return A list with all registered role change color listeners.
      */
     List<RoleChangeColorListener> getRoleChangeColorListeners();
+
+    /**
+     * Adds a listener, which listens to role hoist changes.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<RoleChangeHoistListener> addRoleChangeHoistListener(RoleChangeHoistListener listener);
+
+    /**
+     * Gets a list with all registered role change hoist listeners.
+     *
+     * @return A list with all registered role change hoist listeners.
+     */
+    List<RoleChangeHoistListener> getRoleChangeHoistListeners();
 
     /**
      * Adds a listener, which listens to role permission changes.

--- a/src/main/java/de/btobastian/javacord/DiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/DiscordApi.java
@@ -67,6 +67,7 @@ import de.btobastian.javacord.listeners.server.member.ServerMemberBanListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberJoinListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberLeaveListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberUnbanListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleCreateListener;
@@ -1947,6 +1948,21 @@ public interface DiscordApi {
      * @return A list with all registered user change status listeners.
      */
     List<UserChangeStatusListener> getUserChangeStatusListeners();
+
+    /**
+     * Adds a listener, which listens to role color changes.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<RoleChangeColorListener> addRoleChangeColorListener(RoleChangeColorListener listener);
+
+    /**
+     * Gets a list with all registered role change color listeners.
+     *
+     * @return A list with all registered role change color listeners.
+     */
+    List<RoleChangeColorListener> getRoleChangeColorListeners();
 
     /**
      * Adds a listener, which listens to role permission changes.

--- a/src/main/java/de/btobastian/javacord/DiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/DiscordApi.java
@@ -70,6 +70,7 @@ import de.btobastian.javacord.listeners.server.member.ServerMemberUnbanListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeManagedListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeMentionableListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleCreateListener;
@@ -1995,6 +1996,22 @@ public interface DiscordApi {
      * @return A list with all registered role change managed flag listeners.
      */
     List<RoleChangeManagedListener> getRoleChangeManagedListeners();
+
+    /**
+     * Adds a listener, which listens to role mentionable changes.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<RoleChangeMentionableListener> addRoleChangeMentionableListener(
+            RoleChangeMentionableListener listener);
+
+    /**
+     * Gets a list with all registered role change mentionable listeners.
+     *
+     * @return A list with all registered role change mentionable listeners.
+     */
+    List<RoleChangeMentionableListener> getRoleChangeMentionableListeners();
 
     /**
      * Adds a listener, which listens to role permission changes.

--- a/src/main/java/de/btobastian/javacord/DiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/DiscordApi.java
@@ -2405,4 +2405,35 @@ public interface DiscordApi {
      */
     List<UserChangeAvatarListener> getUserChangeAvatarListeners();
 
+    /**
+     * Removes a global listener.
+     *
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    <T> void removeListener(Class<T> listenerClass, T listener);
+
+    /**
+     * Removes a listener from the message with the given id.
+     *
+     * @param messageId The id of the message.
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    <T> void removeListenerFromMessage(long messageId, Class<T> listenerClass, T listener);
+
+    /**
+     * Removes a listener from the given message.
+     *
+     * @param message The message.
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    default <T> void removeListenerFromMessage(Message message, Class<T> listenerClass, T listener) {
+        removeListenerFromMessage(message.getId(), listenerClass, listener);
+    }
+
 }

--- a/src/main/java/de/btobastian/javacord/DiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/DiscordApi.java
@@ -69,6 +69,7 @@ import de.btobastian.javacord.listeners.server.member.ServerMemberLeaveListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberUnbanListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeManagedListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleCreateListener;
@@ -1979,6 +1980,21 @@ public interface DiscordApi {
      * @return A list with all registered role change hoist listeners.
      */
     List<RoleChangeHoistListener> getRoleChangeHoistListeners();
+
+    /**
+     * Adds a listener, which listens to role managed flag changes.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    ListenerManager<RoleChangeManagedListener> addRoleChangeManagedListener(RoleChangeManagedListener listener);
+
+    /**
+     * Gets a list with all registered role change managed flag listeners.
+     *
+     * @return A list with all registered role change managed flag listeners.
+     */
+    List<RoleChangeManagedListener> getRoleChangeManagedListeners();
 
     /**
      * Adds a listener, which listens to role permission changes.

--- a/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
@@ -711,6 +711,11 @@ public class ImplDiscordApi implements DiscordApi {
         }
     }
 
+    @Override
+    public <T> void removeListenerFromMessage(long messageId, Class<T> listenerClass, T listener) {
+        removeObjectListener(Message.class, messageId, listenerClass, listener);
+    }
+
     /**
      * Gets all object listeners of the given class.
      *
@@ -750,13 +755,7 @@ public class ImplDiscordApi implements DiscordApi {
                 .computeIfAbsent(listener, key -> new ListenerManager<>(this, listener, listenerClass));
     }
 
-    /**
-     * Removes a global listener.
-     *
-     * @param listenerClass The listener class.
-     * @param listener The listener to remove.
-     * @param <T> The type of the listener.
-     */
+    @Override
     @SuppressWarnings("unchecked")
     public <T> void removeListener(Class<T> listenerClass, T listener) {
         synchronized (listeners) {

--- a/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
@@ -60,6 +60,7 @@ import de.btobastian.javacord.listeners.server.member.ServerMemberLeaveListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberUnbanListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeManagedListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleCreateListener;
@@ -1506,6 +1507,16 @@ public class ImplDiscordApi implements DiscordApi {
     @Override
     public List<RoleChangeHoistListener> getRoleChangeHoistListeners() {
         return getListeners(RoleChangeHoistListener.class);
+    }
+
+    @Override
+    public ListenerManager<RoleChangeManagedListener> addRoleChangeManagedListener(RoleChangeManagedListener listener) {
+        return addListener(RoleChangeManagedListener.class, listener);
+    }
+
+    @Override
+    public List<RoleChangeManagedListener> getRoleChangeManagedListeners() {
+        return getListeners(RoleChangeManagedListener.class);
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
@@ -58,6 +58,7 @@ import de.btobastian.javacord.listeners.server.member.ServerMemberBanListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberJoinListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberLeaveListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberUnbanListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleCreateListener;
@@ -1484,6 +1485,16 @@ public class ImplDiscordApi implements DiscordApi {
     @Override
     public List<UserChangeStatusListener> getUserChangeStatusListeners() {
         return getListeners(UserChangeStatusListener.class);
+    }
+
+    @Override
+    public ListenerManager<RoleChangeColorListener> addRoleChangeColorListener(RoleChangeColorListener listener) {
+        return addListener(RoleChangeColorListener.class, listener);
+    }
+
+    @Override
+    public List<RoleChangeColorListener> getRoleChangeColorListeners() {
+        return getListeners(RoleChangeColorListener.class);
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
@@ -61,6 +61,7 @@ import de.btobastian.javacord.listeners.server.member.ServerMemberUnbanListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeManagedListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeMentionableListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleCreateListener;
@@ -1517,6 +1518,17 @@ public class ImplDiscordApi implements DiscordApi {
     @Override
     public List<RoleChangeManagedListener> getRoleChangeManagedListeners() {
         return getListeners(RoleChangeManagedListener.class);
+    }
+
+    @Override
+    public ListenerManager<RoleChangeMentionableListener> addRoleChangeMentionableListener(
+            RoleChangeMentionableListener listener) {
+        return addListener(RoleChangeMentionableListener.class, listener);
+    }
+
+    @Override
+    public List<RoleChangeMentionableListener> getRoleChangeMentionableListeners() {
+        return getListeners(RoleChangeMentionableListener.class);
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
@@ -62,6 +62,7 @@ import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeManagedListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeMentionableListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeNameListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleCreateListener;
@@ -1529,6 +1530,16 @@ public class ImplDiscordApi implements DiscordApi {
     @Override
     public List<RoleChangeMentionableListener> getRoleChangeMentionableListeners() {
         return getListeners(RoleChangeMentionableListener.class);
+    }
+
+    @Override
+    public ListenerManager<RoleChangeNameListener> addRoleChangeNameListener(RoleChangeNameListener listener) {
+        return addListener(RoleChangeNameListener.class, listener);
+    }
+
+    @Override
+    public List<RoleChangeNameListener> getRoleChangeNameListeners() {
+        return getListeners(RoleChangeNameListener.class);
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
@@ -25,7 +25,6 @@ import de.btobastian.javacord.listeners.connection.ResumeListener;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelChangeNameListener;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelCreateListener;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelDeleteListener;
-import de.btobastian.javacord.listeners.message.MessageAttachableListener;
 import de.btobastian.javacord.listeners.message.MessageCreateListener;
 import de.btobastian.javacord.listeners.message.MessageDeleteListener;
 import de.btobastian.javacord.listeners.message.MessageEditListener;
@@ -73,7 +72,6 @@ import de.btobastian.javacord.listeners.user.UserChangeStatusListener;
 import de.btobastian.javacord.listeners.user.UserStartTypingListener;
 import de.btobastian.javacord.listeners.user.channel.PrivateChannelCreateListener;
 import de.btobastian.javacord.listeners.user.channel.PrivateChannelDeleteListener;
-import de.btobastian.javacord.utils.ClassHelper;
 import de.btobastian.javacord.utils.Cleanupable;
 import de.btobastian.javacord.utils.DiscordWebSocketAdapter;
 import de.btobastian.javacord.utils.ListenerManager;
@@ -725,30 +723,6 @@ public class ImplDiscordApi implements DiscordApi {
         }
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public <T extends MessageAttachableListener & ObjectAttachableListener> Collection<ListenerManager<T>>
-    addMessageAttachableListener(long messageId, T listener) {
-        return ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(MessageAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .map(listenerClass -> addObjectListener(Message.class, messageId, listenerClass, listener))
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public <T extends MessageAttachableListener & ObjectAttachableListener>  void removeMessageAttachableListener(
-            long messageId, Class<T> listenerClass, T listener) {
-        removeObjectListener(Message.class, messageId, listenerClass, listener);
-    }
-
-    @Override
-    public <T extends MessageAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>> getMessageAttachableListeners(
-            long messageId) {
-        return getObjectListeners(Message.class, messageId);
-    }
-
     /**
      * Gets a map with all registered listeners that implement one or more {@code ObjectAttachableListener}s and their
      * assigned listener classes they listen to.
@@ -1244,19 +1218,8 @@ public class ImplDiscordApi implements DiscordApi {
     }
 
     @Override
-    public ListenerManager<MessageDeleteListener> addMessageDeleteListener(
-            long messageId, MessageDeleteListener listener) {
-        return addObjectListener(Message.class, messageId, MessageDeleteListener.class, listener);
-    }
-
-    @Override
     public List<MessageDeleteListener> getMessageDeleteListeners() {
         return getListeners(MessageDeleteListener.class);
-    }
-
-    @Override
-    public List<MessageDeleteListener> getMessageDeleteListeners(long messageId) {
-        return getObjectListeners(Message.class, messageId, MessageDeleteListener.class);
     }
 
     @Override
@@ -1265,18 +1228,8 @@ public class ImplDiscordApi implements DiscordApi {
     }
 
     @Override
-    public ListenerManager<MessageEditListener> addMessageEditListener(long messageId, MessageEditListener listener) {
-        return addObjectListener(Message.class, messageId, MessageEditListener.class, listener);
-    }
-
-    @Override
     public List<MessageEditListener> getMessageEditListeners() {
         return getListeners(MessageEditListener.class);
-    }
-
-    @Override
-    public List<MessageEditListener> getMessageEditListeners(long messageId) {
-        return getObjectListeners(Message.class, messageId, MessageEditListener.class);
     }
 
     @Override
@@ -1285,18 +1238,8 @@ public class ImplDiscordApi implements DiscordApi {
     }
 
     @Override
-    public ListenerManager<ReactionAddListener> addReactionAddListener(long messageId, ReactionAddListener listener) {
-        return addObjectListener(Message.class, messageId, ReactionAddListener.class, listener);
-    }
-
-    @Override
     public List<ReactionAddListener> getReactionAddListeners() {
         return getListeners(ReactionAddListener.class);
-    }
-
-    @Override
-    public List<ReactionAddListener> getReactionAddListeners(long messageId) {
-        return getObjectListeners(Message.class, messageId, ReactionAddListener.class);
     }
 
     @Override
@@ -1305,19 +1248,8 @@ public class ImplDiscordApi implements DiscordApi {
     }
 
     @Override
-    public ListenerManager<ReactionRemoveListener> addReactionRemoveListener(
-            long messageId, ReactionRemoveListener listener) {
-        return addObjectListener(Message.class, messageId, ReactionRemoveListener.class, listener);
-    }
-
-    @Override
     public List<ReactionRemoveListener> getReactionRemoveListeners() {
         return getListeners(ReactionRemoveListener.class);
-    }
-
-    @Override
-    public List<ReactionRemoveListener> getReactionRemoveListeners(long messageId) {
-        return getObjectListeners(Message.class, messageId, ReactionRemoveListener.class);
     }
 
     @Override
@@ -1326,19 +1258,8 @@ public class ImplDiscordApi implements DiscordApi {
     }
 
     @Override
-    public ListenerManager<ReactionRemoveAllListener> addReactionRemoveAllListener(
-            long messageId, ReactionRemoveAllListener listener) {
-        return addObjectListener(Message.class, messageId, ReactionRemoveAllListener.class, listener);
-    }
-
-    @Override
     public List<ReactionRemoveAllListener> getReactionRemoveAllListeners() {
         return getListeners(ReactionRemoveAllListener.class);
-    }
-
-    @Override
-    public List<ReactionRemoveAllListener> getReactionRemoveAllListeners(long messageId) {
-        return getObjectListeners(Message.class, messageId, ReactionRemoveAllListener.class);
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
+++ b/src/main/java/de/btobastian/javacord/ImplDiscordApi.java
@@ -59,6 +59,7 @@ import de.btobastian.javacord.listeners.server.member.ServerMemberJoinListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberLeaveListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberUnbanListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleCreateListener;
@@ -1495,6 +1496,16 @@ public class ImplDiscordApi implements DiscordApi {
     @Override
     public List<RoleChangeColorListener> getRoleChangeColorListeners() {
         return getListeners(RoleChangeColorListener.class);
+    }
+
+    @Override
+    public ListenerManager<RoleChangeHoistListener> addRoleChangeHoistListener(RoleChangeHoistListener listener) {
+        return addListener(RoleChangeHoistListener.class, listener);
+    }
+
+    @Override
+    public List<RoleChangeHoistListener> getRoleChangeHoistListeners() {
+        return getListeners(RoleChangeHoistListener.class);
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/entities/Server.java
+++ b/src/main/java/de/btobastian/javacord/entities/Server.java
@@ -2303,4 +2303,15 @@ public interface Server extends DiscordEntity {
                 Server.class, getId(), ServerVoiceChannelMemberLeaveListener.class);
     }
 
+    /**
+     * Removes a listener from this server.
+     *
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    default <T> void removeListener(Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(Server.class, getId(), listenerClass, listener);
+    }
+
 }

--- a/src/main/java/de/btobastian/javacord/entities/Server.java
+++ b/src/main/java/de/btobastian/javacord/entities/Server.java
@@ -59,6 +59,7 @@ import de.btobastian.javacord.listeners.server.member.ServerMemberJoinListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberLeaveListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberUnbanListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleCreateListener;
@@ -2054,6 +2055,26 @@ public interface Server extends DiscordEntity {
      */
     default List<RoleChangeColorListener> getRoleChangeColorListeners() {
         return ((ImplDiscordApi) getApi()).getObjectListeners(Server.class, getId(), RoleChangeColorListener.class);
+    }
+
+    /**
+     * Adds a listener, which listens to role hoist changes in this server.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<RoleChangeHoistListener> addRoleChangeHoistListener(RoleChangeHoistListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                Server.class, getId(), RoleChangeHoistListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered role change hoist listeners.
+     *
+     * @return A list with all registered role change hoist listeners.
+     */
+    default List<RoleChangeHoistListener> getRoleChangeHoistListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Server.class, getId(), RoleChangeHoistListener.class);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/Server.java
+++ b/src/main/java/de/btobastian/javacord/entities/Server.java
@@ -58,6 +58,7 @@ import de.btobastian.javacord.listeners.server.member.ServerMemberBanListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberJoinListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberLeaveListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberUnbanListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleCreateListener;
@@ -2033,6 +2034,26 @@ public interface Server extends DiscordEntity {
      */
     default List<UserChangeStatusListener> getUserChangeStatusListeners() {
         return ((ImplDiscordApi) getApi()).getObjectListeners(Server.class, getId(), UserChangeStatusListener.class);
+    }
+
+    /**
+     * Adds a listener, which listens to role color changes in this server.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<RoleChangeColorListener> addRoleChangeColorListener(RoleChangeColorListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                Server.class, getId(), RoleChangeColorListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered role change color listeners.
+     *
+     * @return A list with all registered role change color listeners.
+     */
+    default List<RoleChangeColorListener> getRoleChangeColorListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Server.class, getId(), RoleChangeColorListener.class);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/Server.java
+++ b/src/main/java/de/btobastian/javacord/entities/Server.java
@@ -62,6 +62,7 @@ import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeManagedListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeMentionableListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeNameListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleCreateListener;
@@ -2120,6 +2121,26 @@ public interface Server extends DiscordEntity {
     default List<RoleChangeMentionableListener> getRoleChangeMentionableListeners() {
         return ((ImplDiscordApi) getApi()).getObjectListeners(
                 Server.class, getId(), RoleChangeMentionableListener.class);
+    }
+
+    /**
+     * Adds a listener, which listens to role name changes in this server.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<RoleChangeNameListener> addRoleChangeNameListener(RoleChangeNameListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                Server.class, getId(), RoleChangeNameListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered role change name listeners.
+     *
+     * @return A list with all registered role change name listeners.
+     */
+    default List<RoleChangeNameListener> getRoleChangeNameListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Server.class, getId(), RoleChangeNameListener.class);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/Server.java
+++ b/src/main/java/de/btobastian/javacord/entities/Server.java
@@ -61,6 +61,7 @@ import de.btobastian.javacord.listeners.server.member.ServerMemberUnbanListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeManagedListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeMentionableListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleCreateListener;
@@ -2097,6 +2098,28 @@ public interface Server extends DiscordEntity {
      */
     default List<RoleChangeManagedListener> getRoleChangeManagedListeners() {
         return ((ImplDiscordApi) getApi()).getObjectListeners(Server.class, getId(), RoleChangeManagedListener.class);
+    }
+
+    /**
+     * Adds a listener, which listens to role mentionable changes in this server.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<RoleChangeMentionableListener> addRoleChangeMentionableListener(
+            RoleChangeMentionableListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                Server.class, getId(), RoleChangeMentionableListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered role change mentionable listeners.
+     *
+     * @return A list with all registered role change mentionable listeners.
+     */
+    default List<RoleChangeMentionableListener> getRoleChangeMentionableListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                Server.class, getId(), RoleChangeMentionableListener.class);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/Server.java
+++ b/src/main/java/de/btobastian/javacord/entities/Server.java
@@ -60,6 +60,7 @@ import de.btobastian.javacord.listeners.server.member.ServerMemberLeaveListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberUnbanListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeManagedListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleCreateListener;
@@ -2075,6 +2076,27 @@ public interface Server extends DiscordEntity {
      */
     default List<RoleChangeHoistListener> getRoleChangeHoistListeners() {
         return ((ImplDiscordApi) getApi()).getObjectListeners(Server.class, getId(), RoleChangeHoistListener.class);
+    }
+
+    /**
+     * Adds a listener, which listens to role managed flag changes in this server.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<RoleChangeManagedListener> addRoleChangeManagedListener(
+            RoleChangeManagedListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                Server.class, getId(), RoleChangeManagedListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered role change managed flag listeners.
+     *
+     * @return A list with all registered role change managed flag listeners.
+     */
+    default List<RoleChangeManagedListener> getRoleChangeManagedListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Server.class, getId(), RoleChangeManagedListener.class);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/User.java
+++ b/src/main/java/de/btobastian/javacord/entities/User.java
@@ -8,6 +8,7 @@ import de.btobastian.javacord.entities.channels.PrivateChannel;
 import de.btobastian.javacord.entities.channels.ServerVoiceChannel;
 import de.btobastian.javacord.entities.message.Messageable;
 import de.btobastian.javacord.entities.permissions.Role;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelChangeNameListener;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelCreateListener;
 import de.btobastian.javacord.listeners.group.channel.GroupChannelDeleteListener;
@@ -23,6 +24,7 @@ import de.btobastian.javacord.listeners.server.member.ServerMemberLeaveListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberUnbanListener;
 import de.btobastian.javacord.listeners.server.role.UserRoleAddListener;
 import de.btobastian.javacord.listeners.server.role.UserRoleRemoveListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 import de.btobastian.javacord.listeners.user.UserChangeActivityListener;
 import de.btobastian.javacord.listeners.user.UserChangeAvatarListener;
 import de.btobastian.javacord.listeners.user.UserChangeNameListener;
@@ -31,11 +33,13 @@ import de.btobastian.javacord.listeners.user.UserChangeStatusListener;
 import de.btobastian.javacord.listeners.user.UserStartTypingListener;
 import de.btobastian.javacord.listeners.user.channel.PrivateChannelCreateListener;
 import de.btobastian.javacord.listeners.user.channel.PrivateChannelDeleteListener;
+import de.btobastian.javacord.utils.ClassHelper;
 import de.btobastian.javacord.utils.ListenerManager;
 
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -731,13 +735,66 @@ public interface User extends DiscordEntity, Messageable, Mentionable {
     }
 
     /**
+     * Adds a listener that implements one or more {@code UserAttachableListener}s.
+     * Adding a listener multiple times will only add it once
+     * and return the same listener managers on each invocation.
+     * The order of invocation is according to first addition.
+     *
+     * @param listener The listener to add.
+     * @param <T> The type of the listener.
+     * @return The managers for the added listener.
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends UserAttachableListener & ObjectAttachableListener> Collection<ListenerManager<T>>
+    addUserAttachableListener(T listener) {
+        return ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(UserAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .map(listenerClass -> ((ImplDiscordApi) getApi()).addObjectListener(User.class, getId(),
+                                                                                    listenerClass, listener))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Removes a listener that implements one or more {@code UserAttachableListener}s.
+     *
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends UserAttachableListener & ObjectAttachableListener> void removeUserAttachableListener(
+            T listener) {
+        ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(UserAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .forEach(listenerClass -> ((ImplDiscordApi) getApi()).removeObjectListener(User.class, getId(),
+                                                                                           listenerClass, listener));
+    }
+
+    /**
+     * Gets a map with all registered listeners that implement one or more {@code UserAttachableListener}s and their
+     * assigned listener classes they listen to.
+     *
+     * @param <T> The type of the listeners.
+     * @return A map with all registered listeners that implement one or more {@code UserAttachableListener}s and their
+     * assigned listener classes they listen to.
+     */
+    default <T extends UserAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getUserAttachableListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(User.class, getId());
+    }
+
+    /**
      * Removes a listener from this user.
      *
      * @param listenerClass The listener class.
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    default <T> void removeListener(Class<T> listenerClass, T listener) {
+    default <T extends UserAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener) {
         ((ImplDiscordApi) getApi()).removeObjectListener(User.class, getId(), listenerClass, listener);
     }
 

--- a/src/main/java/de/btobastian/javacord/entities/User.java
+++ b/src/main/java/de/btobastian/javacord/entities/User.java
@@ -730,4 +730,15 @@ public interface User extends DiscordEntity, Messageable, Mentionable {
                 User.class, getId(), ServerVoiceChannelMemberLeaveListener.class);
     }
 
+    /**
+     * Removes a listener from this user.
+     *
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    default <T> void removeListener(Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(User.class, getId(), listenerClass, listener);
+    }
+
 }

--- a/src/main/java/de/btobastian/javacord/entities/channels/ChannelCategory.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/ChannelCategory.java
@@ -1,12 +1,23 @@
 package de.btobastian.javacord.entities.channels;
 
+import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entities.User;
 import de.btobastian.javacord.entities.impl.ImplServer;
+import de.btobastian.javacord.listeners.ChannelAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.channel.ChannelCategoryAttachableListener;
+import de.btobastian.javacord.listeners.server.channel.ServerChannelAttachableListener;
+import de.btobastian.javacord.utils.ClassHelper;
+import de.btobastian.javacord.utils.ListenerManager;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This class represents a channel category.
@@ -127,6 +138,108 @@ public interface ChannelCategory extends ServerChannel {
             return channel.removeCategory();
         }
         return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Adds a listener that implements one or more {@code ChannelCategoryAttachableListener}s.
+     * Adding a listener multiple times will only add it once
+     * and return the same listener managers on each invocation.
+     * The order of invocation is according to first addition.
+     *
+     * @param listener The listener to add.
+     * @param <T> The type of the listener.
+     * @return The managers for the added listener.
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends ChannelCategoryAttachableListener & ObjectAttachableListener>
+    Collection<ListenerManager<? extends ChannelCategoryAttachableListener>>
+    addChannelCategoryAttachableListener(T listener) {
+        return ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(ChannelCategoryAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .flatMap(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else if (ServerChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addServerChannelAttachableListener(
+                                (ServerChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else {
+                        return Stream.of(((ImplDiscordApi) getApi()).addObjectListener(ChannelCategory.class, getId(),
+                                                                                       listenerClass, listener));
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Removes a listener that implements one or more {@code ChannelCategoryAttachableListener}s.
+     *
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends ChannelCategoryAttachableListener & ObjectAttachableListener> void
+    removeChannelCategoryAttachableListener(T listener) {
+        ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(ChannelCategoryAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .forEach(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else if (ServerChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeServerChannelAttachableListener(
+                                (ServerChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else {
+                        ((ImplDiscordApi) getApi()).removeObjectListener(ChannelCategory.class, getId(),
+                                                                         listenerClass, listener);
+                    }
+                });
+    }
+
+    /**
+     * Gets a map with all registered listeners that implement one or more {@code ChannelCategoryAttachableListener}s
+     * and their assigned listener classes they listen to.
+     *
+     * @param <T> The type of the listeners.
+     * @return A map with all registered listeners that implement one or more
+     * {@code ChannelCategoryAttachableListener}s and their assigned listener classes they listen to.
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends ChannelCategoryAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getChannelCategoryAttachableListeners() {
+        Map<T, List<Class<T>>> channelCategoryListeners =
+                ((ImplDiscordApi) getApi()).getObjectListeners(ChannelCategory.class, getId());
+        getServerChannelAttachableListeners().forEach((listener, listenerClasses) -> channelCategoryListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        getChannelAttachableListeners().forEach((listener, listenerClasses) -> channelCategoryListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        return channelCategoryListeners;
+    }
+
+    /**
+     * Removes a listener from this server text channel.
+     *
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    default <T extends ChannelCategoryAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(ChannelCategory.class, getId(), listenerClass, listener);
     }
 
 }

--- a/src/main/java/de/btobastian/javacord/entities/channels/GroupChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/GroupChannel.java
@@ -119,4 +119,15 @@ public interface GroupChannel extends TextChannel, VoiceChannel {
                 GroupChannel.class, getId(), GroupChannelDeleteListener.class);
     }
 
+    /**
+     * Removes a listener from this group channel.
+     *
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    default <T> void removeListener(Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(GroupChannel.class, getId(), listenerClass, listener);
+    }
+
 }

--- a/src/main/java/de/btobastian/javacord/entities/channels/PrivateChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/PrivateChannel.java
@@ -48,4 +48,15 @@ public interface PrivateChannel extends TextChannel, VoiceChannel {
                 PrivateChannel.class, getId(), PrivateChannelDeleteListener.class);
     }
 
+    /**
+     * Removes a listener from this private channel.
+     *
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    default <T> void removeListener(Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(PrivateChannel.class, getId(), listenerClass, listener);
+    }
+
 }

--- a/src/main/java/de/btobastian/javacord/entities/channels/PrivateChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/PrivateChannel.java
@@ -2,10 +2,18 @@ package de.btobastian.javacord.entities.channels;
 
 import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entities.User;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.TextChannelAttachableListener;
+import de.btobastian.javacord.listeners.user.channel.PrivateChannelAttachableListener;
 import de.btobastian.javacord.listeners.user.channel.PrivateChannelDeleteListener;
+import de.btobastian.javacord.utils.ClassHelper;
 import de.btobastian.javacord.utils.ListenerManager;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This class represents a private channel.
@@ -49,13 +57,91 @@ public interface PrivateChannel extends TextChannel, VoiceChannel {
     }
 
     /**
+     * Adds a listener that implements one or more {@code PrivateChannelAttachableListener}s.
+     * Adding a listener multiple times will only add it once
+     * and return the same listener managers on each invocation.
+     * The order of invocation is according to first addition.
+     *
+     * @param listener The listener to add.
+     * @param <T> The type of the listener.
+     * @return The managers for the added listener.
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends PrivateChannelAttachableListener & ObjectAttachableListener>
+    Collection<ListenerManager<? extends PrivateChannelAttachableListener>> addPrivateChannelAttachableListener(
+            T listener) {
+        return ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(PrivateChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .flatMap(listenerClass -> {
+                    if (TextChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addTextChannelAttachableListener(
+                                (TextChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else {
+                        return Stream.of(((ImplDiscordApi) getApi()).addObjectListener(PrivateChannel.class, getId(),
+                                                                                       listenerClass, listener));
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Removes a listener that implements one or more {@code PrivateChannelAttachableListener}s.
+     *
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends PrivateChannelAttachableListener & ObjectAttachableListener> void
+    removePrivateChannelAttachableListener(T listener) {
+        ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(PrivateChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .forEach(listenerClass -> {
+                    if (TextChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeTextChannelAttachableListener(
+                                (TextChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else {
+                        ((ImplDiscordApi) getApi()).removeObjectListener(PrivateChannel.class, getId(),
+                                                                         listenerClass, listener);
+                    }
+                });
+    }
+
+    /**
+     * Gets a map with all registered listeners that implement one or more {@code PrivateChannelAttachableListener}s and
+     * their assigned listener classes they listen to.
+     *
+     * @param <T> The type of the listeners.
+     * @return A map with all registered listeners that implement one or more {@code PrivateChannelAttachableListener}s
+     * and their assigned listener classes they listen to.
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends PrivateChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getPrivateChannelAttachableListeners() {
+        Map<T, List<Class<T>>> privateChannelListeners =
+                ((ImplDiscordApi) getApi()).getObjectListeners(PrivateChannel.class, getId());
+        getTextChannelAttachableListeners().forEach((listener, listenerClasses) -> privateChannelListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        return privateChannelListeners;
+    }
+
+    /**
      * Removes a listener from this private channel.
      *
      * @param listenerClass The listener class.
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    default <T> void removeListener(Class<T> listenerClass, T listener) {
+    default <T extends PrivateChannelAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener) {
         ((ImplDiscordApi) getApi()).removeObjectListener(PrivateChannel.class, getId(), listenerClass, listener);
     }
 

--- a/src/main/java/de/btobastian/javacord/entities/channels/ServerChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/ServerChannel.java
@@ -427,5 +427,15 @@ public interface ServerChannel extends Channel {
                 ServerChannel.class, getId(), ServerChannelChangeOverwrittenPermissionsListener.class);
     }
 
+    /**
+     * Removes a listener from this server channel.
+     *
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    default <T> void removeListener(Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(ServerChannel.class, getId(), listenerClass, listener);
+    }
 
 }

--- a/src/main/java/de/btobastian/javacord/entities/channels/ServerTextChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/ServerTextChannel.java
@@ -2,6 +2,7 @@ package de.btobastian.javacord.entities.channels;
 
 import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entities.Mentionable;
+import de.btobastian.javacord.listeners.ChannelAttachableListener;
 import de.btobastian.javacord.listeners.ObjectAttachableListener;
 import de.btobastian.javacord.listeners.TextChannelAttachableListener;
 import de.btobastian.javacord.listeners.server.channel.ServerChannelAttachableListener;
@@ -142,7 +143,10 @@ public interface ServerTextChannel extends ServerChannel, TextChannel, Mentionab
                 .filter(ObjectAttachableListener.class::isAssignableFrom)
                 .map(listenerClass -> (Class<T>) listenerClass)
                 .flatMap(listenerClass -> {
-                    if (ServerChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else if (ServerChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
                         return addServerChannelAttachableListener(
                                 (ServerChannelAttachableListener & ObjectAttachableListener) listener).stream();
                     } else if (TextChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
@@ -170,7 +174,10 @@ public interface ServerTextChannel extends ServerChannel, TextChannel, Mentionab
                 .filter(ObjectAttachableListener.class::isAssignableFrom)
                 .map(listenerClass -> (Class<T>) listenerClass)
                 .forEach(listenerClass -> {
-                    if (ServerChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else if (ServerChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
                         removeServerChannelAttachableListener(
                                 (ServerChannelAttachableListener & ObjectAttachableListener) listener);
                     } else if (TextChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
@@ -204,6 +211,13 @@ public interface ServerTextChannel extends ServerChannel, TextChannel, Mentionab
                            return listenerClasses1;
                        }));
         getServerChannelAttachableListeners().forEach((listener, listenerClasses) -> serverTextChannelListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        getChannelAttachableListeners().forEach((listener, listenerClasses) -> serverTextChannelListeners
                 .merge((T) listener,
                        (List<Class<T>>) (Object) listenerClasses,
                        (listenerClasses1, listenerClasses2) -> {

--- a/src/main/java/de/btobastian/javacord/entities/channels/ServerTextChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/ServerTextChannel.java
@@ -2,11 +2,20 @@ package de.btobastian.javacord.entities.channels;
 
 import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entities.Mentionable;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.TextChannelAttachableListener;
+import de.btobastian.javacord.listeners.server.channel.ServerChannelAttachableListener;
+import de.btobastian.javacord.listeners.server.channel.ServerTextChannelAttachableListener;
 import de.btobastian.javacord.listeners.server.channel.ServerTextChannelChangeTopicListener;
+import de.btobastian.javacord.utils.ClassHelper;
 import de.btobastian.javacord.utils.ListenerManager;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This class represents a server text channel.
@@ -115,13 +124,104 @@ public interface ServerTextChannel extends ServerChannel, TextChannel, Mentionab
     }
 
     /**
+     * Adds a listener that implements one or more {@code ServerTextChannelAttachableListener}s.
+     * Adding a listener multiple times will only add it once
+     * and return the same listener managers on each invocation.
+     * The order of invocation is according to first addition.
+     *
+     * @param listener The listener to add.
+     * @param <T> The type of the listener.
+     * @return The managers for the added listener.
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends ServerTextChannelAttachableListener & ObjectAttachableListener>
+    Collection<ListenerManager<? extends ServerTextChannelAttachableListener>>
+    addServerTextChannelAttachableListener(T listener) {
+        return ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(ServerTextChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .flatMap(listenerClass -> {
+                    if (ServerChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addServerChannelAttachableListener(
+                                (ServerChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else if (TextChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addTextChannelAttachableListener(
+                                (TextChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else {
+                        return Stream.of(((ImplDiscordApi) getApi()).addObjectListener(ServerTextChannel.class, getId(),
+                                                                                       listenerClass, listener));
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Removes a listener that implements one or more {@code ServerTextChannelAttachableListener}s.
+     *
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends ServerTextChannelAttachableListener & ObjectAttachableListener> void
+    removeServerTextChannelAttachableListener(T listener) {
+        ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(ServerTextChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .forEach(listenerClass -> {
+                    if (ServerChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeServerChannelAttachableListener(
+                                (ServerChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else if (TextChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeTextChannelAttachableListener(
+                                (TextChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else {
+                        ((ImplDiscordApi) getApi()).removeObjectListener(ServerTextChannel.class, getId(),
+                                                                         listenerClass, listener);
+                    }
+                });
+    }
+
+    /**
+     * Gets a map with all registered listeners that implement one or more {@code ServerTextChannelAttachableListener}s
+     * and their assigned listener classes they listen to.
+     *
+     * @param <T> The type of the listeners.
+     * @return A map with all registered listeners that implement one or more
+     * {@code ServerTextChannelAttachableListener}s and their assigned listener classes they listen to.
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends ServerTextChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getServerTextChannelAttachableListeners() {
+        Map<T, List<Class<T>>> serverTextChannelListeners =
+                ((ImplDiscordApi) getApi()).getObjectListeners(ServerTextChannel.class, getId());
+        getTextChannelAttachableListeners().forEach((listener, listenerClasses) -> serverTextChannelListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        getServerChannelAttachableListeners().forEach((listener, listenerClasses) -> serverTextChannelListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        return serverTextChannelListeners;
+    }
+
+    /**
      * Removes a listener from this server text channel.
      *
      * @param listenerClass The listener class.
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    default <T> void removeListener(Class<T> listenerClass, T listener) {
+    default <T extends ServerTextChannelAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener) {
         ((ImplDiscordApi) getApi()).removeObjectListener(ServerTextChannel.class, getId(), listenerClass, listener);
     }
 

--- a/src/main/java/de/btobastian/javacord/entities/channels/ServerTextChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/ServerTextChannel.java
@@ -114,4 +114,15 @@ public interface ServerTextChannel extends ServerChannel, TextChannel, Mentionab
                 .getObjectListeners(ServerTextChannel.class, getId(), ServerTextChannelChangeTopicListener.class);
     }
 
+    /**
+     * Removes a listener from this server text channel.
+     *
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    default <T> void removeListener(Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(ServerTextChannel.class, getId(), listenerClass, listener);
+    }
+
 }

--- a/src/main/java/de/btobastian/javacord/entities/channels/TextChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/TextChannel.java
@@ -1338,4 +1338,15 @@ public interface TextChannel extends Channel, Messageable {
                 .getObjectListeners(TextChannel.class, getId(), ReactionRemoveAllListener.class);
     }
 
+    /**
+     * Removes a listener from this text channel.
+     *
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    default <T> void removeListener(Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(TextChannel.class, getId(), listenerClass, listener);
+    }
+
 }

--- a/src/main/java/de/btobastian/javacord/entities/channels/VoiceChannel.java
+++ b/src/main/java/de/btobastian/javacord/entities/channels/VoiceChannel.java
@@ -1,9 +1,20 @@
 package de.btobastian.javacord.entities.channels;
 
+import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entities.User;
 import de.btobastian.javacord.entities.permissions.PermissionType;
+import de.btobastian.javacord.listeners.ChannelAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.VoiceChannelAttachableListener;
+import de.btobastian.javacord.utils.ClassHelper;
+import de.btobastian.javacord.utils.ListenerManager;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This class represents a voice channel.
@@ -66,6 +77,94 @@ public interface VoiceChannel extends Channel {
      */
     default boolean canYouMuteUsers() {
         return canMuteUsers(getApi().getYourself());
+    }
+
+    /**
+     * Adds a listener that implements one or more {@code VoiceChannelAttachableListener}s.
+     * Adding a listener multiple times will only add it once
+     * and return the same listener managers on each invocation.
+     * The order of invocation is according to first addition.
+     *
+     * @param listener The listener to add.
+     * @param <T> The type of the listener.
+     * @return The managers for the added listener.
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends VoiceChannelAttachableListener & ObjectAttachableListener>
+    Collection<ListenerManager<? extends VoiceChannelAttachableListener>>
+    addVoiceChannelAttachableListener(T listener) {
+        return ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(VoiceChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .flatMap(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else {
+                        return Stream.of(((ImplDiscordApi) getApi()).addObjectListener(VoiceChannel.class, getId(),
+                                                                                       listenerClass, listener));
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Removes a listener that implements one or more {@code VoiceChannelAttachableListener}s.
+     *
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends VoiceChannelAttachableListener & ObjectAttachableListener> void
+    removeVoiceChannelAttachableListener(T listener) {
+        ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(VoiceChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .forEach(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else {
+                        ((ImplDiscordApi) getApi()).removeObjectListener(VoiceChannel.class, getId(),
+                                                                         listenerClass, listener);
+                    }
+                });
+    }
+
+    /**
+     * Gets a map with all registered listeners that implement one or more {@code VoiceChannelAttachableListener}s and
+     * their assigned listener classes they listen to.
+     *
+     * @param <T> The type of the listeners.
+     * @return A map with all registered listeners that implement one or more {@code VoiceChannelAttachableListener}s
+     * and their assigned listener classes they listen to.
+     */
+    default <T extends VoiceChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getVoiceChannelAttachableListeners() {
+        Map<T, List<Class<T>>> voiceChannelListeners =
+                ((ImplDiscordApi) getApi()).getObjectListeners(VoiceChannel.class, getId());
+        getChannelAttachableListeners().forEach((listener, listenerClasses) -> voiceChannelListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        return voiceChannelListeners;
+    }
+
+    /**
+     * Removes a listener from this voice channel.
+     *
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    default <T extends VoiceChannelAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(VoiceChannel.class, getId(), listenerClass, listener);
     }
 
 }

--- a/src/main/java/de/btobastian/javacord/entities/message/Message.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/Message.java
@@ -20,6 +20,8 @@ import de.btobastian.javacord.entities.message.emoji.impl.ImplCustomEmoji;
 import de.btobastian.javacord.entities.message.emoji.impl.ImplUnicodeEmoji;
 import de.btobastian.javacord.entities.permissions.PermissionType;
 import de.btobastian.javacord.entities.permissions.Role;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.message.MessageAttachableListener;
 import de.btobastian.javacord.listeners.message.MessageDeleteListener;
 import de.btobastian.javacord.listeners.message.MessageEditListener;
 import de.btobastian.javacord.listeners.message.reaction.ReactionAddListener;
@@ -34,7 +36,9 @@ import de.btobastian.javacord.utils.rest.RestRequest;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
@@ -1272,8 +1276,7 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      */
     default ListenerManager<ReactionRemoveAllListener> addReactionRemoveAllListener(
             ReactionRemoveAllListener listener) {
-        return ((ImplDiscordApi) getApi())
-                .addObjectListener(Message.class, getId(), ReactionRemoveAllListener.class, listener);
+        return getApi().addReactionRemoveAllListener(getId(), listener);
     }
 
     /**
@@ -1282,7 +1285,48 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @return A list with all registered reaction remove all listeners.
      */
     default List<ReactionRemoveAllListener> getReactionRemoveAllListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(Message.class, getId(), ReactionRemoveAllListener.class);
+        return getApi().getReactionRemoveAllListeners(getId());
+    }
+
+    /**
+     * Adds a listener that implements one or more {@code MessageAttachableListener}s.
+     * Adding a listener multiple times will only add it once
+     * and return the same listener managers on each invocation.
+     * The order of invocation is according to first addition.
+     *
+     * @param listener The listener to add.
+     * @param <T> The type of the listener.
+     * @return The managers for the added listener.
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends MessageAttachableListener & ObjectAttachableListener> Collection<ListenerManager<T>>
+    addMessageAttachableListener(T listener) {
+        return getApi().addMessageAttachableListener(getId(), listener);
+    }
+
+    /**
+     * Removes a listener that implements one or more {@code MessageAttachableListener}s.
+     *
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends MessageAttachableListener & ObjectAttachableListener> void removeMessageAttachableListener(
+            T listener) {
+        getApi().removeMessageAttachableListener(getId(), listener);
+    }
+
+    /**
+     * Gets a map with all registered listeners that implement one or more {@code MessageAttachableListener}s and their
+     * assigned listener classes they listen to.
+     *
+     * @param <T> The type of the listeners.
+     * @return A map with all registered listeners that implement one or more {@code MessageAttachableListener}s and
+     * their assigned listener classes they listen to.
+     */
+    default <T extends MessageAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getMessageAttachableListeners() {
+        return getApi().getMessageAttachableListeners(getId());
     }
 
     /**
@@ -1292,8 +1336,9 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    default <T> void removeListener(Class<T> listenerClass, T listener) {
-        ((ImplDiscordApi) getApi()).removeObjectListener(Message.class, getId(), listenerClass, listener);
+    default <T extends MessageAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener) {
+        getApi().removeMessageAttachableListener(getId(), listenerClass, listener);
     }
 
 }

--- a/src/main/java/de/btobastian/javacord/entities/message/Message.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/Message.java
@@ -27,6 +27,7 @@ import de.btobastian.javacord.listeners.message.MessageEditListener;
 import de.btobastian.javacord.listeners.message.reaction.ReactionAddListener;
 import de.btobastian.javacord.listeners.message.reaction.ReactionRemoveAllListener;
 import de.btobastian.javacord.listeners.message.reaction.ReactionRemoveListener;
+import de.btobastian.javacord.utils.ClassHelper;
 import de.btobastian.javacord.utils.DiscordRegexPattern;
 import de.btobastian.javacord.utils.ListenerManager;
 import de.btobastian.javacord.utils.rest.RestEndpoint;
@@ -37,6 +38,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -44,6 +46,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -355,6 +358,527 @@ public interface Message extends DiscordEntity, Comparable<Message> {
             future.completeExceptionally(e);
             return future;
         }
+    }
+
+    /**
+     * Adds a listener, which listens to message deletions of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message which should be listened to.
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    static ListenerManager<MessageDeleteListener> addMessageDeleteListener(
+            DiscordApi api, long messageId, MessageDeleteListener listener) {
+        return ((ImplDiscordApi) api).addObjectListener(
+                Message.class, messageId, MessageDeleteListener.class, listener);
+    }
+
+    /**
+     * Adds a listener, which listens to message deletions of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param message The message which should be listened to.
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    static ListenerManager<MessageDeleteListener> addMessageDeleteListener(
+            DiscordApi api, Message message, MessageDeleteListener listener) {
+        return addMessageDeleteListener(api, message.getId(), listener);
+    }
+
+    /**
+     * Gets a list with all registered message delete listeners of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message.
+     * @return A list with all registered message delete listeners.
+     */
+    static List<MessageDeleteListener> getMessageDeleteListeners(DiscordApi api, long messageId) {
+        return ((ImplDiscordApi) api).getObjectListeners(Message.class, messageId, MessageDeleteListener.class);
+    }
+
+    /**
+     * Gets a list with all registered message delete listeners of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message.
+     * @return A list with all registered message delete listeners.
+     */
+    static List<MessageDeleteListener> getMessageDeleteListeners(DiscordApi api, String messageId) {
+        try {
+            return getMessageDeleteListeners(api, Long.valueOf(messageId));
+        } catch (NumberFormatException ignored) {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Gets a list with all registered message delete listeners of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param message The message.
+     * @return A list with all registered message delete listeners.
+     */
+    static List<MessageDeleteListener> getMessageDeleteListeners(DiscordApi api, Message message) {
+        return getMessageDeleteListeners(api, message.getId());
+    }
+
+    /**
+     * Adds a listener, which listens to message edits of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message which should be listened to.
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    static ListenerManager<MessageEditListener> addMessageEditListener(
+            DiscordApi api, long messageId, MessageEditListener listener) {
+        return ((ImplDiscordApi) api).addObjectListener(Message.class, messageId, MessageEditListener.class, listener);
+    }
+
+    /**
+     * Adds a listener, which listens to message edits of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param message The message which should be listened to.
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    static ListenerManager<MessageEditListener> addMessageEditListener(
+            DiscordApi api, Message message, MessageEditListener listener) {
+        return addMessageEditListener(api, message.getId(), listener);
+    }
+
+    /**
+     * Gets a list with all registered message edit listeners of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message.
+     * @return A list with all registered message edit listeners.
+     */
+    static List<MessageEditListener> getMessageEditListeners(DiscordApi api, long messageId) {
+        return ((ImplDiscordApi) api).getObjectListeners(Message.class, messageId, MessageEditListener.class);
+    }
+
+    /**
+     * Gets a list with all registered message edit listeners of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message.
+     * @return A list with all registered message edit listeners.
+     */
+    static List<MessageEditListener> getMessageEditListeners(DiscordApi api, String messageId) {
+        try {
+            return getMessageEditListeners(api, Long.valueOf(messageId));
+        } catch (NumberFormatException ignored) {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Gets a list with all registered message edit listeners of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param message The message.
+     * @return A list with all registered message edit listeners.
+     */
+    static List<MessageEditListener> getMessageEditListeners(DiscordApi api, Message message) {
+        return getMessageEditListeners(api, message.getId());
+    }
+
+    /**
+     * Adds a listener, which listens to reactions being added to a specific message.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message which should be listened to.
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    static ListenerManager<ReactionAddListener> addReactionAddListener(
+            DiscordApi api, long messageId, ReactionAddListener listener) {
+        return ((ImplDiscordApi) api).addObjectListener(Message.class, messageId, ReactionAddListener.class, listener);
+    }
+
+    /**
+     * Adds a listener, which listens to reactions being added to a specific message.
+     *
+     * @param api The discord api instance.
+     * @param message The message which should be listened to.
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    static ListenerManager<ReactionAddListener> addReactionAddListener(
+            DiscordApi api, Message message, ReactionAddListener listener) {
+        return addReactionAddListener(api, message.getId(), listener);
+    }
+
+    /**
+     * Gets a list with all registered reaction add listeners of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message.
+     * @return A list with all registered reaction add listeners.
+     */
+    static List<ReactionAddListener> getReactionAddListeners(DiscordApi api, long messageId) {
+        return ((ImplDiscordApi) api).getObjectListeners(Message.class, messageId, ReactionAddListener.class);
+    }
+
+    /**
+     * Gets a list with all registered reaction add listeners of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message.
+     * @return A list with all registered reaction add listeners.
+     */
+    static List<ReactionAddListener> getReactionAddListeners(DiscordApi api, String messageId) {
+        try {
+            return getReactionAddListeners(api, Long.valueOf(messageId));
+        } catch (NumberFormatException ignored) {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Gets a list with all registered reaction add listeners of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param message The message.
+     * @return A list with all registered reaction add listeners.
+     */
+    static List<ReactionAddListener> getReactionAddListeners(DiscordApi api, Message message) {
+        return getReactionAddListeners(api, message.getId());
+    }
+
+    /**
+     * Adds a listener, which listens to reactions being removed from a specific message.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message which should be listened to.
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    static ListenerManager<ReactionRemoveListener> addReactionRemoveListener(
+            DiscordApi api, long messageId, ReactionRemoveListener listener) {
+        return ((ImplDiscordApi) api).addObjectListener(
+                Message.class, messageId, ReactionRemoveListener.class, listener);
+    }
+
+    /**
+     * Adds a listener, which listens to reactions being removed from a specific message.
+     *
+     * @param api The discord api instance.
+     * @param message The message which should be listened to.
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    static ListenerManager<ReactionRemoveListener> addReactionRemoveListener(
+            DiscordApi api, Message message, ReactionRemoveListener listener) {
+        return addReactionRemoveListener(api, message.getId(), listener);
+    }
+
+    /**
+     * Gets a list with all registered reaction remove listeners of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message.
+     * @return A list with all registered reaction remove listeners.
+     */
+    static List<ReactionRemoveListener> getReactionRemoveListeners(DiscordApi api, long messageId) {
+        return ((ImplDiscordApi) api).getObjectListeners(Message.class, messageId, ReactionRemoveListener.class);
+    }
+
+    /**
+     * Gets a list with all registered reaction remove listeners of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message.
+     * @return A list with all registered reaction remove listeners.
+     */
+    static List<ReactionRemoveListener> getReactionRemoveListeners(DiscordApi api, String messageId) {
+        try {
+            return getReactionRemoveListeners(api, Long.valueOf(messageId));
+        } catch (NumberFormatException ignored) {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Gets a list with all registered reaction remove listeners of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param message The message.
+     * @return A list with all registered reaction remove listeners.
+     */
+    static List<ReactionRemoveListener> getReactionRemoveListeners(DiscordApi api, Message message) {
+        return getReactionRemoveListeners(api, message.getId());
+    }
+
+    /**
+     * Adds a listener, which listens to all reactions being removed from a specific message at once.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message which should be listened to.
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    static ListenerManager<ReactionRemoveAllListener> addReactionRemoveAllListener(
+            DiscordApi api, long messageId, ReactionRemoveAllListener listener) {
+        return ((ImplDiscordApi) api).addObjectListener(
+                Message.class, messageId, ReactionRemoveAllListener.class, listener);
+    }
+
+    /**
+     * Adds a listener, which listens to all reactions being removed from a specific message at once.
+     *
+     * @param api The discord api instance.
+     * @param message The message which should be listened to.
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    static ListenerManager<ReactionRemoveAllListener> addReactionRemoveAllListener(
+            DiscordApi api, Message message, ReactionRemoveAllListener listener) {
+        return addReactionRemoveAllListener(api, message.getId(), listener);
+    }
+
+    /**
+     * Gets a list with all registered reaction remove all listeners of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message.
+     * @return A list with all registered reaction remove all listeners.
+     */
+    static List<ReactionRemoveAllListener> getReactionRemoveAllListeners(DiscordApi api, long messageId) {
+        return ((ImplDiscordApi) api).getObjectListeners(Message.class, messageId, ReactionRemoveAllListener.class);
+    }
+
+    /**
+     * Gets a list with all registered reaction remove all listeners of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message.
+     * @return A list with all registered reaction remove all listeners.
+     */
+    static List<ReactionRemoveAllListener> getReactionRemoveAllListeners(DiscordApi api, String messageId) {
+        try {
+            return getReactionRemoveAllListeners(api, Long.valueOf(messageId));
+        } catch (NumberFormatException ignored) {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Gets a list with all registered reaction remove all listeners of a specific message.
+     *
+     * @param api The discord api instance.
+     * @param message The message.
+     * @return A list with all registered reaction remove all listeners.
+     */
+    static List<ReactionRemoveAllListener> getReactionRemoveAllListeners(DiscordApi api, Message message) {
+        return getReactionRemoveAllListeners(api, message.getId());
+    }
+
+    /**
+     * Adds a listener that implements one or more {@code MessageAttachableListener}s to the message with the given id.
+     * Adding a listener multiple times will only add it once
+     * and return the same listener managers on each invocation.
+     * The order of invocation is according to first addition.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message which should be listened to.
+     * @param listener The listener to add.
+     * @param <T> The type of the listener.
+     * @return The managers for the added listener.
+     */
+    @SuppressWarnings("unchecked")
+    static <T extends MessageAttachableListener & ObjectAttachableListener> Collection<ListenerManager<T>>
+    addMessageAttachableListener(DiscordApi api, long messageId, T listener) {
+        return ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(MessageAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .map(listenerClass -> ((ImplDiscordApi) api).addObjectListener(
+                        Message.class, messageId, listenerClass, listener))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Adds a listener that implements one or more {@code MessageAttachableListener}s to the message with the given id.
+     * Adding a listener multiple times will only add it once
+     * and return the same listener managers on each invocation.
+     * The order of invocation is according to first addition.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message which should be listened to.
+     * @param listener The listener to add.
+     * @param <T> The type of the listener.
+     * @return The managers for the added listener.
+     */
+    static <T extends MessageAttachableListener & ObjectAttachableListener> Collection<ListenerManager<T>>
+    addMessageAttachableListener(DiscordApi api, String messageId, T listener) {
+        try {
+            return addMessageAttachableListener(api, Long.valueOf(messageId), listener);
+        } catch (NumberFormatException ignored) {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Adds a listener that implements one or more {@code MessageAttachableListener}s to the given message.
+     * Adding a listener multiple times will only add it once
+     * and return the same listener managers on each invocation.
+     * The order of invocation is according to first addition.
+     *
+     * @param api The discord api instance.
+     * @param message The message which should be listened to.
+     * @param listener The listener to add.
+     * @param <T> The type of the listener.
+     * @return The managers for the added listener.
+     */
+    static <T extends MessageAttachableListener & ObjectAttachableListener> Collection<ListenerManager<T>>
+    addMessageAttachableListener(DiscordApi api, Message message, T listener) {
+        return addMessageAttachableListener(api, message.getId(), listener);
+    }
+
+    /**
+     * Removes a {@code MessageAttachableListener} from the message with the given id.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message.
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    static <T extends MessageAttachableListener & ObjectAttachableListener> void removeListener(
+            DiscordApi api, long messageId, Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) api).removeObjectListener(Message.class, messageId, listenerClass, listener);
+    }
+
+    /**
+     * Removes a {@code MessageAttachableListener} from the message with the given id.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message.
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    static <T extends MessageAttachableListener & ObjectAttachableListener> void removeListener(
+            DiscordApi api, String messageId, Class<T> listenerClass, T listener) {
+        try {
+            removeListener(api, Long.valueOf(messageId), listenerClass, listener);
+        } catch (NumberFormatException ignored) { }
+    }
+
+    /**
+     * Removes a listener that implements one or more {@code MessageAttachableListener}s from the given message.
+     *
+     * @param api The discord api instance.
+     * @param message The message.
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    static <T extends MessageAttachableListener & ObjectAttachableListener> void removeListener(
+            DiscordApi api, Message message, Class<T> listenerClass, T listener) {
+        removeListener(api, message.getId(), listenerClass, listener);
+    }
+
+    /**
+     * Removes a listener that implements one or more {@code MessageAttachableListener}s from the message with the given
+     * id.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    @SuppressWarnings("unchecked")
+    static <T extends MessageAttachableListener & ObjectAttachableListener> void removeMessageAttachableListener(
+            DiscordApi api, long messageId, T listener) {
+        ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(MessageAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .forEach(listenerClass -> removeListener(api, messageId, listenerClass, listener));
+    }
+
+    /**
+     * Removes a listener that implements one or more {@code MessageAttachableListener}s from the message with the given
+     * id.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    static <T extends MessageAttachableListener & ObjectAttachableListener> void removeMessageAttachableListener(
+            DiscordApi api, String messageId, T listener) {
+        try {
+            removeMessageAttachableListener(api, Long.valueOf(messageId), listener);
+        } catch (NumberFormatException ignored) { }
+    }
+
+    /**
+     * Removes a listener that implements one or more {@code MessageAttachableListener}s from the given message.
+     *
+     * @param api The discord api instance.
+     * @param message The message.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    static <T extends MessageAttachableListener & ObjectAttachableListener> void removeMessageAttachableListener(
+            DiscordApi api, Message message, T listener) {
+        removeMessageAttachableListener(api, message.getId(), listener);
+    }
+
+    /**
+     * Gets a map with all registered listeners that implement one or more {@code MessageAttachableListener}s and their
+     * assigned listener classes they listen to for the message with the given id.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message.
+     * @param <T> The type of the listeners.
+     * @return A map with all registered listeners that implement one or more {@code MessageAttachableListener}s and
+     * their assigned listener classes they listen to.
+     */
+    static <T extends MessageAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getMessageAttachableListeners(DiscordApi api, long messageId) {
+        return ((ImplDiscordApi) api).getObjectListeners(Message.class, messageId);
+    }
+
+    /**
+     * Gets a map with all registered listeners that implement one or more {@code MessageAttachableListener}s and their
+     * assigned listener classes they listen to for the message with the given id.
+     *
+     * @param api The discord api instance.
+     * @param messageId The id of the message.
+     * @param <T> The type of the listeners.
+     * @return A map with all registered listeners that implement one or more {@code MessageAttachableListener}s and
+     * their assigned listener classes they listen to.
+     */
+    static <T extends MessageAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getMessageAttachableListeners(DiscordApi api, String messageId) {
+        try {
+            return getMessageAttachableListeners(api, Long.valueOf(messageId));
+        } catch (NumberFormatException ignored) {
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Gets a map with all registered listeners that implement one or more {@code MessageAttachableListener}s and their
+     * assigned listener classes they listen to for the given message.
+     *
+     * @param api The discord api instance.
+     * @param message The message.
+     * @param <T> The type of the listeners.
+     * @return A map with all registered listeners that implement one or more {@code MessageAttachableListener}s and
+     * their assigned listener classes they listen to.
+     */
+    static <T extends MessageAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getMessageAttachableListeners(DiscordApi api, Message message) {
+        return getMessageAttachableListeners(api, message.getId());
     }
 
     /**
@@ -1199,7 +1723,7 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @return The manager of the listener.
      */
     default ListenerManager<MessageDeleteListener> addMessageDeleteListener(MessageDeleteListener listener) {
-        return getApi().addMessageDeleteListener(getId(), listener);
+        return addMessageDeleteListener(getApi(), getId(), listener);
     }
 
     /**
@@ -1208,7 +1732,7 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @return A list with all registered message delete listeners.
      */
     default List<MessageDeleteListener> getMessageDeleteListeners() {
-        return getApi().getMessageDeleteListeners(getId());
+        return getMessageDeleteListeners(getApi(), getId());
     }
 
     /**
@@ -1218,7 +1742,7 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @return The manager of the listener.
      */
     default ListenerManager<MessageEditListener> addMessageEditListener(MessageEditListener listener) {
-        return getApi().addMessageEditListener(getId(), listener);
+        return addMessageEditListener(getApi(), getId(), listener);
     }
 
     /**
@@ -1227,7 +1751,7 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @return A list with all registered message edit listeners.
      */
     default List<MessageEditListener> getMessageEditListeners() {
-        return getApi().getMessageEditListeners(getId());
+        return getMessageEditListeners(getApi(), getId());
     }
 
     /**
@@ -1237,7 +1761,7 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @return The manager of the listener.
      */
     default ListenerManager<ReactionAddListener> addReactionAddListener(ReactionAddListener listener) {
-        return getApi().addReactionAddListener(getId(), listener);
+        return addReactionAddListener(getApi(), getId(), listener);
     }
 
     /**
@@ -1246,7 +1770,7 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @return A list with all registered reaction add listeners.
      */
     default List<ReactionAddListener> getReactionAddListeners() {
-        return getApi().getReactionAddListeners(getId());
+        return getReactionAddListeners(getApi(), getId());
     }
 
     /**
@@ -1256,7 +1780,7 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @return The manager of the listener.
      */
     default ListenerManager<ReactionRemoveListener> addReactionRemoveListener(ReactionRemoveListener listener) {
-        return getApi().addReactionRemoveListener(getId(), listener);
+        return addReactionRemoveListener(getApi(), getId(), listener);
     }
 
     /**
@@ -1265,7 +1789,7 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @return A list with all registered reaction remove listeners.
      */
     default List<ReactionRemoveListener> getReactionRemoveListeners() {
-        return getApi().getReactionRemoveListeners(getId());
+        return getReactionRemoveListeners(getApi(), getId());
     }
 
     /**
@@ -1276,7 +1800,7 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      */
     default ListenerManager<ReactionRemoveAllListener> addReactionRemoveAllListener(
             ReactionRemoveAllListener listener) {
-        return getApi().addReactionRemoveAllListener(getId(), listener);
+        return addReactionRemoveAllListener(getApi(), getId(), listener);
     }
 
     /**
@@ -1285,7 +1809,7 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @return A list with all registered reaction remove all listeners.
      */
     default List<ReactionRemoveAllListener> getReactionRemoveAllListeners() {
-        return getApi().getReactionRemoveAllListeners(getId());
+        return getReactionRemoveAllListeners(getApi(), getId());
     }
 
     /**
@@ -1298,10 +1822,9 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @param <T> The type of the listener.
      * @return The managers for the added listener.
      */
-    @SuppressWarnings("unchecked")
     default <T extends MessageAttachableListener & ObjectAttachableListener> Collection<ListenerManager<T>>
     addMessageAttachableListener(T listener) {
-        return getApi().addMessageAttachableListener(getId(), listener);
+        return addMessageAttachableListener(getApi(), getId(), listener);
     }
 
     /**
@@ -1310,10 +1833,9 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    @SuppressWarnings("unchecked")
     default <T extends MessageAttachableListener & ObjectAttachableListener> void removeMessageAttachableListener(
             T listener) {
-        getApi().removeMessageAttachableListener(getId(), listener);
+        removeMessageAttachableListener(getApi(), getId(), listener);
     }
 
     /**
@@ -1326,7 +1848,7 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      */
     default <T extends MessageAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
     getMessageAttachableListeners() {
-        return getApi().getMessageAttachableListeners(getId());
+        return getMessageAttachableListeners(getApi(), getId());
     }
 
     /**
@@ -1338,7 +1860,7 @@ public interface Message extends DiscordEntity, Comparable<Message> {
      */
     default <T extends MessageAttachableListener & ObjectAttachableListener> void removeListener(
             Class<T> listenerClass, T listener) {
-        getApi().removeMessageAttachableListener(getId(), listenerClass, listener);
+        removeListener(getApi(), getId(), listenerClass, listener);
     }
 
 }

--- a/src/main/java/de/btobastian/javacord/entities/message/Message.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/Message.java
@@ -1285,4 +1285,15 @@ public interface Message extends DiscordEntity, Comparable<Message> {
         return ((ImplDiscordApi) getApi()).getObjectListeners(Message.class, getId(), ReactionRemoveAllListener.class);
     }
 
+    /**
+     * Removes a listener from this message.
+     *
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    default <T> void removeListener(Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(Message.class, getId(), listenerClass, listener);
+    }
+
 }

--- a/src/main/java/de/btobastian/javacord/entities/message/emoji/CustomEmoji.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/emoji/CustomEmoji.java
@@ -5,16 +5,22 @@ import de.btobastian.javacord.entities.DiscordEntity;
 import de.btobastian.javacord.entities.Icon;
 import de.btobastian.javacord.entities.Server;
 import de.btobastian.javacord.entities.impl.ImplIcon;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.emoji.CustomEmojiAttachableListener;
 import de.btobastian.javacord.listeners.server.emoji.CustomEmojiChangeNameListener;
 import de.btobastian.javacord.listeners.server.emoji.CustomEmojiDeleteListener;
+import de.btobastian.javacord.utils.ClassHelper;
 import de.btobastian.javacord.utils.ListenerManager;
 import de.btobastian.javacord.utils.logging.LoggerUtil;
 import org.slf4j.Logger;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * This class represents a custom emoji.
@@ -116,13 +122,66 @@ public interface CustomEmoji extends DiscordEntity, Emoji {
     }
 
     /**
+     * Adds a listener that implements one or more {@code CustomEmojiAttachableListener}s.
+     * Adding a listener multiple times will only add it once
+     * and return the same listener managers on each invocation.
+     * The order of invocation is according to first addition.
+     *
+     * @param listener The listener to add.
+     * @param <T> The type of the listener.
+     * @return The managers for the added listener.
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends CustomEmojiAttachableListener & ObjectAttachableListener> Collection<ListenerManager<T>>
+    addCustomEmojiAttachableListener(T listener) {
+        return ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(CustomEmojiAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .map(listenerClass -> ((ImplDiscordApi) getApi()).addObjectListener(CustomEmoji.class, getId(),
+                                                                                    listenerClass, listener))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Removes a listener that implements one or more {@code CustomEmojiAttachableListener}s.
+     *
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    @SuppressWarnings("unchecked")
+    default <T extends CustomEmojiAttachableListener & ObjectAttachableListener> void
+    removeCustomEmojiAttachableListener(T listener) {
+        ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(CustomEmojiAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .forEach(listenerClass -> ((ImplDiscordApi) getApi()).removeObjectListener(CustomEmoji.class, getId(),
+                                                                                           listenerClass, listener));
+    }
+
+    /**
+     * Gets a map with all registered listeners that implement one or more {@code CustomEmojiAttachableListener}s and
+     * their assigned listener classes they listen to.
+     *
+     * @param <T> The type of the listeners.
+     * @return A map with all registered listeners that implement one or more {@code CustomEmojiAttachableListener}s and
+     * their assigned listener classes they listen to.
+     */
+    default <T extends CustomEmojiAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getCustomEmojiAttachableListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(CustomEmoji.class, getId());
+    }
+
+    /**
      * Removes a listener from this custom emoji.
      *
      * @param listenerClass The listener class.
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    default <T> void removeListener(Class<T> listenerClass, T listener) {
+    default <T extends CustomEmojiAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener) {
         ((ImplDiscordApi) getApi()).removeObjectListener(CustomEmoji.class, getId(), listenerClass, listener);
     }
 

--- a/src/main/java/de/btobastian/javacord/entities/message/emoji/CustomEmoji.java
+++ b/src/main/java/de/btobastian/javacord/entities/message/emoji/CustomEmoji.java
@@ -115,4 +115,15 @@ public interface CustomEmoji extends DiscordEntity, Emoji {
                 .getObjectListeners(CustomEmoji.class, getId(), CustomEmojiDeleteListener.class);
     }
 
+    /**
+     * Removes a listener from this custom emoji.
+     *
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    default <T> void removeListener(Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(CustomEmoji.class, getId(), listenerClass, listener);
+    }
+
 }

--- a/src/main/java/de/btobastian/javacord/entities/permissions/Role.java
+++ b/src/main/java/de/btobastian/javacord/entities/permissions/Role.java
@@ -10,6 +10,7 @@ import de.btobastian.javacord.listeners.server.channel.ServerChannelChangeOverwr
 import de.btobastian.javacord.listeners.server.role.RoleAttachableListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeManagedListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleDeleteListener;
@@ -268,6 +269,27 @@ public interface Role extends DiscordEntity, Mentionable {
      */
     default List<RoleChangeHoistListener> getRoleChangeHoistListeners() {
         return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangeHoistListener.class);
+    }
+
+    /**
+     * Adds a listener, which listens to managed flag changes of this role.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<RoleChangeManagedListener> addRoleChangeManagedListener(
+            RoleChangeManagedListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                Role.class, getId(), RoleChangeManagedListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered role change managed flag listeners.
+     *
+     * @return A list with all registered role change managed flag listeners.
+     */
+    default List<RoleChangeManagedListener> getRoleChangeManagedListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangeManagedListener.class);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/permissions/Role.java
+++ b/src/main/java/de/btobastian/javacord/entities/permissions/Role.java
@@ -11,6 +11,7 @@ import de.btobastian.javacord.listeners.server.role.RoleAttachableListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeManagedListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeMentionableListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleDeleteListener;
@@ -290,6 +291,27 @@ public interface Role extends DiscordEntity, Mentionable {
      */
     default List<RoleChangeManagedListener> getRoleChangeManagedListeners() {
         return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangeManagedListener.class);
+    }
+
+    /**
+     * Adds a listener, which listens to mentionable changes of this role.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<RoleChangeMentionableListener> addRoleChangeMentionableListener(
+            RoleChangeMentionableListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                Role.class, getId(), RoleChangeMentionableListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered role change mentionable listeners.
+     *
+     * @return A list with all registered role change mentionable listeners.
+     */
+    default List<RoleChangeMentionableListener> getRoleChangeMentionableListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangeMentionableListener.class);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/permissions/Role.java
+++ b/src/main/java/de/btobastian/javacord/entities/permissions/Role.java
@@ -12,6 +12,7 @@ import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeManagedListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeMentionableListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeNameListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleDeleteListener;
@@ -312,6 +313,26 @@ public interface Role extends DiscordEntity, Mentionable {
      */
     default List<RoleChangeMentionableListener> getRoleChangeMentionableListeners() {
         return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangeMentionableListener.class);
+    }
+
+    /**
+     * Adds a listener, which listens to name changes of this role.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<RoleChangeNameListener> addRoleChangeNameListener(RoleChangeNameListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                Role.class, getId(), RoleChangeNameListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered role change name listeners.
+     *
+     * @return A list with all registered role change name listeners.
+     */
+    default List<RoleChangeNameListener> getRoleChangeNameListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangeNameListener.class);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/permissions/Role.java
+++ b/src/main/java/de/btobastian/javacord/entities/permissions/Role.java
@@ -9,6 +9,7 @@ import de.btobastian.javacord.listeners.ObjectAttachableListener;
 import de.btobastian.javacord.listeners.server.channel.ServerChannelChangeOverwrittenPermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleAttachableListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleDeleteListener;
@@ -247,6 +248,26 @@ public interface Role extends DiscordEntity, Mentionable {
      */
     default List<RoleChangeColorListener> getRoleChangeColorListeners() {
         return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangeColorListener.class);
+    }
+
+    /**
+     * Adds a listener, which listens to hoist changes of this role.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<RoleChangeHoistListener> addRoleChangeHoistListener(RoleChangeHoistListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                Role.class, getId(), RoleChangeHoistListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered role change hoist listeners.
+     *
+     * @return A list with all registered role change hoist listeners.
+     */
+    default List<RoleChangeHoistListener> getRoleChangeHoistListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangeHoistListener.class);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/entities/permissions/Role.java
+++ b/src/main/java/de/btobastian/javacord/entities/permissions/Role.java
@@ -8,6 +8,7 @@ import de.btobastian.javacord.entities.User;
 import de.btobastian.javacord.listeners.ObjectAttachableListener;
 import de.btobastian.javacord.listeners.server.channel.ServerChannelChangeOverwrittenPermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleAttachableListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.listeners.server.role.RoleDeleteListener;
@@ -229,6 +230,26 @@ public interface Role extends DiscordEntity, Mentionable {
     }
 
     /**
+     * Adds a listener, which listens to color changes of this role.
+     *
+     * @param listener The listener to add.
+     * @return The manager of the listener.
+     */
+    default ListenerManager<RoleChangeColorListener> addRoleChangeColorListener(RoleChangeColorListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                Role.class, getId(), RoleChangeColorListener.class, listener);
+    }
+
+    /**
+     * Gets a list with all registered role change color listeners.
+     *
+     * @return A list with all registered role change color listeners.
+     */
+    default List<RoleChangeColorListener> getRoleChangeColorListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangeColorListener.class);
+    }
+
+    /**
      * Adds a listener, which listens to permission changes of this role.
      *
      * @param listener The listener to add.
@@ -245,7 +266,7 @@ public interface Role extends DiscordEntity, Mentionable {
      *
      * @return A list with all registered role change permissions listeners.
      */
-    default java.util.List<RoleChangePermissionsListener> getRoleChangePermissionsListeners() {
+    default List<RoleChangePermissionsListener> getRoleChangePermissionsListeners() {
         return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangePermissionsListener.class);
     }
 

--- a/src/main/java/de/btobastian/javacord/entities/permissions/Role.java
+++ b/src/main/java/de/btobastian/javacord/entities/permissions/Role.java
@@ -347,4 +347,15 @@ public interface Role extends DiscordEntity, Mentionable {
         return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), UserRoleRemoveListener.class);
     }
 
+    /**
+     * Removes a listener from this role.
+     *
+     * @param listenerClass The listener class.
+     * @param listener The listener to remove.
+     * @param <T> The type of the listener.
+     */
+    default <T> void removeListener(Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(Role.class, getId(), listenerClass, listener);
+    }
+
 }

--- a/src/main/java/de/btobastian/javacord/entities/permissions/impl/ImplRole.java
+++ b/src/main/java/de/btobastian/javacord/entities/permissions/impl/ImplRole.java
@@ -150,6 +150,15 @@ public class ImplRole implements Role {
     }
 
     /**
+     * Sets the mentionable flag of the role.
+     *
+     * @param mentionable The mentionable flag to set.
+     */
+    public void setMentionable(boolean mentionable) {
+        this.mentionable = mentionable;
+    }
+
+    /**
      * Sets the permissions of the role.
      *
      * @param permissions The permissions to set.

--- a/src/main/java/de/btobastian/javacord/entities/permissions/impl/ImplRole.java
+++ b/src/main/java/de/btobastian/javacord/entities/permissions/impl/ImplRole.java
@@ -132,6 +132,15 @@ public class ImplRole implements Role {
     }
 
     /**
+     * Sets the hoist flag of the role.
+     *
+     * @param hoist The hoist flag to set.
+     */
+    public void setHoist(boolean hoist) {
+        this.hoist = hoist;
+    }
+
+    /**
      * Sets the permissions of the role.
      *
      * @param permissions The permissions to set.

--- a/src/main/java/de/btobastian/javacord/entities/permissions/impl/ImplRole.java
+++ b/src/main/java/de/btobastian/javacord/entities/permissions/impl/ImplRole.java
@@ -114,6 +114,24 @@ public class ImplRole implements Role {
     }
 
     /**
+     * Gets the color of the role as {@code int}.
+     *
+     * @return The color of the role as {@code int}.
+     */
+    public int getColorAsInt() {
+        return color;
+    }
+
+    /**
+     * Sets the color of the role.
+     *
+     * @param color The color to set.
+     */
+    public void setColor(int color) {
+        this.color = color;
+    }
+
+    /**
      * Sets the permissions of the role.
      *
      * @param permissions The permissions to set.

--- a/src/main/java/de/btobastian/javacord/entities/permissions/impl/ImplRole.java
+++ b/src/main/java/de/btobastian/javacord/entities/permissions/impl/ImplRole.java
@@ -159,6 +159,15 @@ public class ImplRole implements Role {
     }
 
     /**
+     * Sets the name of the role.
+     *
+     * @param name The name to set.
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
      * Sets the permissions of the role.
      *
      * @param permissions The permissions to set.

--- a/src/main/java/de/btobastian/javacord/entities/permissions/impl/ImplRole.java
+++ b/src/main/java/de/btobastian/javacord/entities/permissions/impl/ImplRole.java
@@ -141,6 +141,15 @@ public class ImplRole implements Role {
     }
 
     /**
+     * Sets the managed flag of the role.
+     *
+     * @param managed The managed flag to set.
+     */
+    public void setManaged(boolean managed) {
+        this.managed = managed;
+    }
+
+    /**
      * Sets the permissions of the role.
      *
      * @param permissions The permissions to set.

--- a/src/main/java/de/btobastian/javacord/events/server/role/RoleChangeColorEvent.java
+++ b/src/main/java/de/btobastian/javacord/events/server/role/RoleChangeColorEvent.java
@@ -4,11 +4,17 @@ import de.btobastian.javacord.DiscordApi;
 import de.btobastian.javacord.entities.permissions.Role;
 
 import java.awt.Color;
+import java.util.Optional;
 
 /**
  * A role change color event.
  */
 public class RoleChangeColorEvent extends RoleEvent {
+
+    /**
+     * The new color value.
+     */
+    private final Color newColor;
 
     /**
      * The old color value.
@@ -20,10 +26,12 @@ public class RoleChangeColorEvent extends RoleEvent {
      *
      * @param api The api instance of the event.
      * @param role The role of the event.
+     * @param newColor The new color of the role.
      * @param oldColor The old color of the role.
      */
-    public RoleChangeColorEvent(DiscordApi api, Role role, Color oldColor) {
+    public RoleChangeColorEvent(DiscordApi api, Role role, Color newColor, Color oldColor) {
         super(api, role);
+        this.newColor = newColor;
         this.oldColor = oldColor;
     }
 
@@ -32,8 +40,8 @@ public class RoleChangeColorEvent extends RoleEvent {
      *
      * @return The old color of the role.
      */
-    public Color getOldColor() {
-        return oldColor;
+    public Optional<Color> getOldColor() {
+        return Optional.ofNullable(oldColor);
     }
 
     /**
@@ -41,8 +49,7 @@ public class RoleChangeColorEvent extends RoleEvent {
      *
      * @return The new color of the role.
      */
-    public Color getNewColor() {
-        // TODO: return getRole().getColor();
-        return null;
+    public Optional<Color> getNewColor() {
+        return Optional.ofNullable(newColor);
     }
 }

--- a/src/main/java/de/btobastian/javacord/events/server/role/RoleChangeNameEvent.java
+++ b/src/main/java/de/btobastian/javacord/events/server/role/RoleChangeNameEvent.java
@@ -9,6 +9,11 @@ import de.btobastian.javacord.entities.permissions.Role;
 public class RoleChangeNameEvent extends RoleEvent {
 
     /**
+     * The new name of the role.
+     */
+    private final String newName;
+
+    /**
      * The old name of the role.
      */
     private final String oldName;
@@ -18,10 +23,12 @@ public class RoleChangeNameEvent extends RoleEvent {
      *
      * @param api The api instance of the event.
      * @param role The role of the event.
+     * @param newName The new name of the role.
      * @param oldName The old name of the role.
      */
-    public RoleChangeNameEvent(DiscordApi api, Role role, String oldName) {
+    public RoleChangeNameEvent(DiscordApi api, Role role, String newName, String oldName) {
         super(api, role);
+        this.newName = newName;
         this.oldName = oldName;
     }
 
@@ -40,7 +47,6 @@ public class RoleChangeNameEvent extends RoleEvent {
      * @return The new name of the role.
      */
     public String getNewName() {
-        // TODO: return getRole().getName();
-        return null;
+        return newName;
     }
 }

--- a/src/main/java/de/btobastian/javacord/listeners/ChannelAttachableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/ChannelAttachableListener.java
@@ -1,0 +1,11 @@
+package de.btobastian.javacord.listeners;
+
+import de.btobastian.javacord.entities.channels.Channel;
+import de.btobastian.javacord.listeners.server.channel.ServerChannelAttachableListener;
+
+/**
+ * This is a marker interface for listeners that can be attached to a {@link Channel}.
+ */
+public interface ChannelAttachableListener
+        extends TextChannelAttachableListener, VoiceChannelAttachableListener, ServerChannelAttachableListener {
+}

--- a/src/main/java/de/btobastian/javacord/listeners/GloballyAttachableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/GloballyAttachableListener.java
@@ -1,0 +1,9 @@
+package de.btobastian.javacord.listeners;
+
+import de.btobastian.javacord.DiscordApi;
+
+/**
+ * This is a marker interface for listeners that can be attached to a {@link DiscordApi}.
+ */
+public interface GloballyAttachableListener {
+}

--- a/src/main/java/de/btobastian/javacord/listeners/ObjectAttachableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/ObjectAttachableListener.java
@@ -1,0 +1,7 @@
+package de.btobastian.javacord.listeners;
+
+/**
+ * This is a marker interface for listeners that can be attached to an object.
+ */
+public interface ObjectAttachableListener {
+}

--- a/src/main/java/de/btobastian/javacord/listeners/TextChannelAttachableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/TextChannelAttachableListener.java
@@ -1,0 +1,13 @@
+package de.btobastian.javacord.listeners;
+
+import de.btobastian.javacord.entities.channels.TextChannel;
+import de.btobastian.javacord.listeners.group.channel.GroupChannelAttachableListener;
+import de.btobastian.javacord.listeners.server.channel.ServerTextChannelAttachableListener;
+import de.btobastian.javacord.listeners.user.channel.PrivateChannelAttachableListener;
+
+/**
+ * This is a marker interface for listeners that can be attached to a {@link TextChannel}.
+ */
+public interface TextChannelAttachableListener
+        extends ServerTextChannelAttachableListener, GroupChannelAttachableListener, PrivateChannelAttachableListener {
+}

--- a/src/main/java/de/btobastian/javacord/listeners/VoiceChannelAttachableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/VoiceChannelAttachableListener.java
@@ -1,0 +1,13 @@
+package de.btobastian.javacord.listeners;
+
+import de.btobastian.javacord.entities.channels.VoiceChannel;
+import de.btobastian.javacord.listeners.group.channel.GroupChannelAttachableListener;
+import de.btobastian.javacord.listeners.server.channel.ServerVoiceChannelAttachableListener;
+import de.btobastian.javacord.listeners.user.channel.PrivateChannelAttachableListener;
+
+/**
+ * This is a marker interface for listeners that can be attached to a {@link VoiceChannel}.
+ */
+public interface VoiceChannelAttachableListener
+        extends ServerVoiceChannelAttachableListener, GroupChannelAttachableListener, PrivateChannelAttachableListener {
+}

--- a/src/main/java/de/btobastian/javacord/listeners/connection/LostConnectionListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/connection/LostConnectionListener.java
@@ -1,6 +1,7 @@
 package de.btobastian.javacord.listeners.connection;
 
 import de.btobastian.javacord.events.connection.LostConnectionEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
 
 /**
  * This listener listens to lost connections.
@@ -9,7 +10,7 @@ import de.btobastian.javacord.events.connection.LostConnectionEvent;
  * to resume the session without missing any events!
  */
 @FunctionalInterface
-public interface LostConnectionListener {
+public interface LostConnectionListener extends GloballyAttachableListener {
 
     /**
      * This method is called every time a connection is lost.

--- a/src/main/java/de/btobastian/javacord/listeners/connection/ReconnectListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/connection/ReconnectListener.java
@@ -1,13 +1,14 @@
 package de.btobastian.javacord.listeners.connection;
 
 import de.btobastian.javacord.events.connection.ReconnectEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
 
 /**
  * This listener listens to reconnected sessions.
  * Reconnecting a session, means that it's likely that events were lost and therefore all objects were replaced.
  */
 @FunctionalInterface
-public interface ReconnectListener {
+public interface ReconnectListener extends GloballyAttachableListener {
 
     /**
      * This method is called every time a connection is reconnected.

--- a/src/main/java/de/btobastian/javacord/listeners/connection/ResumeListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/connection/ResumeListener.java
@@ -1,13 +1,14 @@
 package de.btobastian.javacord.listeners.connection;
 
 import de.btobastian.javacord.events.connection.ResumeEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
 
 /**
  * This listener listens to resumed sessions.
  * Resuming a session, means no events were missed and all objects are still valid.
  */
 @FunctionalInterface
-public interface ResumeListener {
+public interface ResumeListener extends GloballyAttachableListener {
 
     /**
      * This method is called every time a connection is resumed.

--- a/src/main/java/de/btobastian/javacord/listeners/group/channel/GroupChannelAttachableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/group/channel/GroupChannelAttachableListener.java
@@ -1,0 +1,9 @@
+package de.btobastian.javacord.listeners.group.channel;
+
+import de.btobastian.javacord.entities.channels.GroupChannel;
+
+/**
+ * This is a marker interface for listeners that can be attached to a {@link GroupChannel}.
+ */
+public interface GroupChannelAttachableListener {
+}

--- a/src/main/java/de/btobastian/javacord/listeners/group/channel/GroupChannelChangeNameListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/group/channel/GroupChannelChangeNameListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.group.channel;
 
 import de.btobastian.javacord.events.group.channel.GroupChannelChangeNameEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 
 /**
  * This listener listens to group channel name changes.
  */
 @FunctionalInterface
-public interface GroupChannelChangeNameListener {
+public interface GroupChannelChangeNameListener extends UserAttachableListener, GroupChannelAttachableListener,
+                                                        GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a group channel's name changes.

--- a/src/main/java/de/btobastian/javacord/listeners/group/channel/GroupChannelCreateListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/group/channel/GroupChannelCreateListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.group.channel;
 
 import de.btobastian.javacord.events.group.channel.GroupChannelCreateEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 
 /**
  * This listener listens to group channel creations.
  */
 @FunctionalInterface
-public interface GroupChannelCreateListener {
+public interface GroupChannelCreateListener extends UserAttachableListener, GloballyAttachableListener,
+                                                    ObjectAttachableListener {
 
     /**
      * This method is called every time a group channel is created.

--- a/src/main/java/de/btobastian/javacord/listeners/group/channel/GroupChannelDeleteListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/group/channel/GroupChannelDeleteListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.group.channel;
 
 import de.btobastian.javacord.events.group.channel.GroupChannelDeleteEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 
 /**
  * This listener listens to group channel deletions.
  */
 @FunctionalInterface
-public interface GroupChannelDeleteListener {
+public interface GroupChannelDeleteListener extends UserAttachableListener, GroupChannelAttachableListener,
+                                                    GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a group channel is deleted.

--- a/src/main/java/de/btobastian/javacord/listeners/message/MessageAttachableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/message/MessageAttachableListener.java
@@ -1,0 +1,9 @@
+package de.btobastian.javacord.listeners.message;
+
+import de.btobastian.javacord.entities.message.Message;
+
+/**
+ * This is a marker interface for listeners that can be attached to a {@link Message}.
+ */
+public interface MessageAttachableListener {
+}

--- a/src/main/java/de/btobastian/javacord/listeners/message/MessageCreateListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/message/MessageCreateListener.java
@@ -1,12 +1,19 @@
 package de.btobastian.javacord.listeners.message;
 
 import de.btobastian.javacord.events.message.MessageCreateEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.TextChannelAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 
 /**
  * This listener listens to message creations.
  */
 @FunctionalInterface
-public interface MessageCreateListener {
+public interface MessageCreateListener extends ServerAttachableListener, UserAttachableListener,
+                                               TextChannelAttachableListener, GloballyAttachableListener,
+                                               ObjectAttachableListener {
 
     /**
      * This method is called every time a message is created.

--- a/src/main/java/de/btobastian/javacord/listeners/message/MessageDeleteListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/message/MessageDeleteListener.java
@@ -1,12 +1,18 @@
 package de.btobastian.javacord.listeners.message;
 
 import de.btobastian.javacord.events.message.MessageDeleteEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.TextChannelAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to message deletions.
  */
 @FunctionalInterface
-public interface MessageDeleteListener {
+public interface MessageDeleteListener extends ServerAttachableListener, TextChannelAttachableListener,
+                                               MessageAttachableListener, GloballyAttachableListener,
+                                               ObjectAttachableListener {
 
     /**
      * This method is called every time a message is deleted.

--- a/src/main/java/de/btobastian/javacord/listeners/message/MessageEditListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/message/MessageEditListener.java
@@ -1,12 +1,18 @@
 package de.btobastian.javacord.listeners.message;
 
 import de.btobastian.javacord.events.message.MessageEditEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.TextChannelAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to message edits.
  */
 @FunctionalInterface
-public interface MessageEditListener {
+public interface MessageEditListener extends ServerAttachableListener, TextChannelAttachableListener,
+                                             MessageAttachableListener, GloballyAttachableListener,
+                                             ObjectAttachableListener {
 
     /**
      * This method is called every time a message is edited.

--- a/src/main/java/de/btobastian/javacord/listeners/message/reaction/ReactionAddListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/message/reaction/ReactionAddListener.java
@@ -1,12 +1,20 @@
 package de.btobastian.javacord.listeners.message.reaction;
 
 import de.btobastian.javacord.events.message.reaction.ReactionAddEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.TextChannelAttachableListener;
+import de.btobastian.javacord.listeners.message.MessageAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 
 /**
  * This listener listens to reaction adding.
  */
 @FunctionalInterface
-public interface ReactionAddListener {
+public interface ReactionAddListener extends ServerAttachableListener, UserAttachableListener,
+                                             TextChannelAttachableListener, MessageAttachableListener,
+                                             GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a reaction is added to a message.

--- a/src/main/java/de/btobastian/javacord/listeners/message/reaction/ReactionRemoveAllListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/message/reaction/ReactionRemoveAllListener.java
@@ -1,12 +1,19 @@
 package de.btobastian.javacord.listeners.message.reaction;
 
 import de.btobastian.javacord.events.message.reaction.ReactionRemoveAllEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.TextChannelAttachableListener;
+import de.btobastian.javacord.listeners.message.MessageAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to all reaction being delete at once.
  */
 @FunctionalInterface
-public interface ReactionRemoveAllListener {
+public interface ReactionRemoveAllListener extends ServerAttachableListener, TextChannelAttachableListener,
+                                                   MessageAttachableListener, GloballyAttachableListener,
+                                                   ObjectAttachableListener {
 
     /**
      * This method is called every time all reactions were removed from a message.

--- a/src/main/java/de/btobastian/javacord/listeners/message/reaction/ReactionRemoveListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/message/reaction/ReactionRemoveListener.java
@@ -1,12 +1,20 @@
 package de.btobastian.javacord.listeners.message.reaction;
 
 import de.btobastian.javacord.events.message.reaction.ReactionRemoveEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.TextChannelAttachableListener;
+import de.btobastian.javacord.listeners.message.MessageAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 
 /**
  * This listener listens to reaction deletions.
  */
 @FunctionalInterface
-public interface ReactionRemoveListener {
+public interface ReactionRemoveListener extends ServerAttachableListener, UserAttachableListener,
+                                                TextChannelAttachableListener, MessageAttachableListener,
+                                                GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a reaction is removed from a message.

--- a/src/main/java/de/btobastian/javacord/listeners/server/ServerAttachableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/ServerAttachableListener.java
@@ -1,0 +1,9 @@
+package de.btobastian.javacord.listeners.server;
+
+import de.btobastian.javacord.entities.Server;
+
+/**
+ * This is a marker interface for listeners that can be attached to a {@link Server}.
+ */
+public interface ServerAttachableListener {
+}

--- a/src/main/java/de/btobastian/javacord/listeners/server/ServerBecomesAvailableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/ServerBecomesAvailableListener.java
@@ -1,6 +1,7 @@
 package de.btobastian.javacord.listeners.server;
 
 import de.btobastian.javacord.events.server.ServerBecomesAvailableEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
 
 /**
  * This listener listens to servers becoming unavailable.
@@ -9,7 +10,7 @@ import de.btobastian.javacord.events.server.ServerBecomesAvailableEvent;
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-unavailability">Discord docs</a>
  */
 @FunctionalInterface
-public interface ServerBecomesAvailableListener {
+public interface ServerBecomesAvailableListener extends GloballyAttachableListener {
 
     /**
      * This method is called every time a server became unavailable.

--- a/src/main/java/de/btobastian/javacord/listeners/server/ServerBecomesUnavailableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/ServerBecomesUnavailableListener.java
@@ -1,6 +1,8 @@
 package de.btobastian.javacord.listeners.server;
 
 import de.btobastian.javacord.events.server.ServerBecomesUnavailableEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
 
 /**
  * This listener listens to servers becoming available.
@@ -9,7 +11,8 @@ import de.btobastian.javacord.events.server.ServerBecomesUnavailableEvent;
  * @see <a href="https://discordapp.com/developers/docs/topics/gateway#guild-unavailability">Discord docs</a>
  */
 @FunctionalInterface
-public interface ServerBecomesUnavailableListener {
+public interface ServerBecomesUnavailableListener extends ServerAttachableListener, GloballyAttachableListener,
+                                                          ObjectAttachableListener {
 
     /**
      * This method is called every time a server became available.

--- a/src/main/java/de/btobastian/javacord/listeners/server/ServerChangeDefaultMessageNotificationLevelListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/ServerChangeDefaultMessageNotificationLevelListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.server;
 
 import de.btobastian.javacord.events.server.ServerChangeDefaultMessageNotificationLevelEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
 
 /**
  * This listener listens to server default message notification level changes.
  */
 @FunctionalInterface
-public interface ServerChangeDefaultMessageNotificationLevelListener {
+public interface ServerChangeDefaultMessageNotificationLevelListener extends ServerAttachableListener,
+                                                                             GloballyAttachableListener,
+                                                                             ObjectAttachableListener {
 
     /**
      * This method is called every time a server's default message notification level changed.

--- a/src/main/java/de/btobastian/javacord/listeners/server/ServerChangeExplicitContentFilterLevelListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/ServerChangeExplicitContentFilterLevelListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.server;
 
 import de.btobastian.javacord.events.server.ServerChangeExplicitContentFilterLevelEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
 
 /**
  * This listener listens to server explicit content filter level changes.
  */
 @FunctionalInterface
-public interface ServerChangeExplicitContentFilterLevelListener {
+public interface ServerChangeExplicitContentFilterLevelListener extends ServerAttachableListener,
+                                                                        GloballyAttachableListener,
+                                                                        ObjectAttachableListener {
 
     /**
      * This method is called every time a server's explicit content filter level changed.

--- a/src/main/java/de/btobastian/javacord/listeners/server/ServerChangeIconListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/ServerChangeIconListener.java
@@ -1,12 +1,15 @@
 package de.btobastian.javacord.listeners.server;
 
 import de.btobastian.javacord.events.server.ServerChangeIconEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
 
 /**
  * This listener listens to server icon changes.
  */
 @FunctionalInterface
-public interface ServerChangeIconListener {
+public interface ServerChangeIconListener extends ServerAttachableListener, GloballyAttachableListener,
+                                                  ObjectAttachableListener {
 
     /**
      * This method is called every time a server's icon changed.

--- a/src/main/java/de/btobastian/javacord/listeners/server/ServerChangeMultiFactorAuthenticationLevelListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/ServerChangeMultiFactorAuthenticationLevelListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.server;
 
 import de.btobastian.javacord.events.server.ServerChangeMultiFactorAuthenticationLevelEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
 
 /**
  * This listener listens to server multi factor authentication level changes.
  */
 @FunctionalInterface
-public interface ServerChangeMultiFactorAuthenticationLevelListener {
+public interface ServerChangeMultiFactorAuthenticationLevelListener extends ServerAttachableListener,
+                                                                            GloballyAttachableListener,
+                                                                            ObjectAttachableListener {
 
     /**
      * This method is called every time a server's multi factor authentication level changed.

--- a/src/main/java/de/btobastian/javacord/listeners/server/ServerChangeNameListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/ServerChangeNameListener.java
@@ -1,12 +1,15 @@
 package de.btobastian.javacord.listeners.server;
 
 import de.btobastian.javacord.events.server.ServerChangeNameEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
 
 /**
  * This listener listens to server name changes.
  */
 @FunctionalInterface
-public interface ServerChangeNameListener {
+public interface ServerChangeNameListener extends ServerAttachableListener, GloballyAttachableListener,
+                                                  ObjectAttachableListener {
 
     /**
      * This method is called every time a server's name changed.

--- a/src/main/java/de/btobastian/javacord/listeners/server/ServerChangeOwnerListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/ServerChangeOwnerListener.java
@@ -1,12 +1,15 @@
 package de.btobastian.javacord.listeners.server;
 
 import de.btobastian.javacord.events.server.ServerChangeOwnerEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
 
 /**
  * This listener listens to server owner changes.
  */
 @FunctionalInterface
-public interface ServerChangeOwnerListener {
+public interface ServerChangeOwnerListener extends ServerAttachableListener, GloballyAttachableListener,
+                                                   ObjectAttachableListener {
 
     /**
      * This method is called every time a server's owner changed.

--- a/src/main/java/de/btobastian/javacord/listeners/server/ServerChangeRegionListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/ServerChangeRegionListener.java
@@ -1,12 +1,15 @@
 package de.btobastian.javacord.listeners.server;
 
 import de.btobastian.javacord.events.server.ServerChangeRegionEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
 
 /**
  * This listener listens to server region changes.
  */
 @FunctionalInterface
-public interface ServerChangeRegionListener {
+public interface ServerChangeRegionListener extends ServerAttachableListener, GloballyAttachableListener,
+                                                    ObjectAttachableListener {
 
     /**
      * This method is called every time a server's region changed.

--- a/src/main/java/de/btobastian/javacord/listeners/server/ServerChangeVerificationLevelListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/ServerChangeVerificationLevelListener.java
@@ -1,12 +1,15 @@
 package de.btobastian.javacord.listeners.server;
 
 import de.btobastian.javacord.events.server.ServerChangeVerificationLevelEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
 
 /**
  * This listener listens to server verification level changes.
  */
 @FunctionalInterface
-public interface ServerChangeVerificationLevelListener {
+public interface ServerChangeVerificationLevelListener extends ServerAttachableListener, GloballyAttachableListener,
+                                                               ObjectAttachableListener {
 
     /**
      * This method is called every time a server's verification level changed.

--- a/src/main/java/de/btobastian/javacord/listeners/server/ServerJoinListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/ServerJoinListener.java
@@ -1,6 +1,7 @@
 package de.btobastian.javacord.listeners.server;
 
 import de.btobastian.javacord.events.server.ServerJoinEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
 import de.btobastian.javacord.listeners.server.member.ServerMemberJoinListener;
 
 /**
@@ -9,7 +10,7 @@ import de.btobastian.javacord.listeners.server.member.ServerMemberJoinListener;
  * ServerMemberAddListener is for other users and ServerJoinListener is for yourself!
  */
 @FunctionalInterface
-public interface ServerJoinListener {
+public interface ServerJoinListener extends GloballyAttachableListener {
 
     /**
      * This method is called every time you join a server.

--- a/src/main/java/de/btobastian/javacord/listeners/server/ServerLeaveListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/ServerLeaveListener.java
@@ -1,6 +1,8 @@
 package de.btobastian.javacord.listeners.server;
 
 import de.btobastian.javacord.events.server.ServerLeaveEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
 
 /**
  * This listener listens to server leaves.
@@ -8,7 +10,8 @@ import de.btobastian.javacord.events.server.ServerLeaveEvent;
  * ServerMemberRemoveListener is for other users and ServerLeaveListener is for yourself!
  */
 @FunctionalInterface
-public interface ServerLeaveListener {
+public interface ServerLeaveListener extends ServerAttachableListener, GloballyAttachableListener,
+                                             ObjectAttachableListener {
 
     /**
      * This method is called every time you leave a server.

--- a/src/main/java/de/btobastian/javacord/listeners/server/channel/ChannelCategoryAttachableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/channel/ChannelCategoryAttachableListener.java
@@ -1,0 +1,9 @@
+package de.btobastian.javacord.listeners.server.channel;
+
+import de.btobastian.javacord.entities.channels.ChannelCategory;
+
+/**
+ * This is a marker interface for listeners that can be attached to a {@link ChannelCategory}.
+ */
+public interface ChannelCategoryAttachableListener {
+}

--- a/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerChannelAttachableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerChannelAttachableListener.java
@@ -1,0 +1,10 @@
+package de.btobastian.javacord.listeners.server.channel;
+
+import de.btobastian.javacord.entities.channels.ServerChannel;
+
+/**
+ * This is a marker interface for listeners that can be attached to a {@link ServerChannel}.
+ */
+public interface ServerChannelAttachableListener extends
+        ServerTextChannelAttachableListener, ServerVoiceChannelAttachableListener {
+}

--- a/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerChannelAttachableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerChannelAttachableListener.java
@@ -6,5 +6,5 @@ import de.btobastian.javacord.entities.channels.ServerChannel;
  * This is a marker interface for listeners that can be attached to a {@link ServerChannel}.
  */
 public interface ServerChannelAttachableListener extends
-        ServerTextChannelAttachableListener, ServerVoiceChannelAttachableListener {
+        ServerTextChannelAttachableListener, ServerVoiceChannelAttachableListener, ChannelCategoryAttachableListener {
 }

--- a/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerChannelChangeNameListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerChannelChangeNameListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.server.channel;
 
 import de.btobastian.javacord.events.server.channel.ServerChannelChangeNameEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to server channel name changes.
  */
 @FunctionalInterface
-public interface ServerChannelChangeNameListener {
+public interface ServerChannelChangeNameListener extends ServerAttachableListener, ServerChannelAttachableListener,
+                                                         GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a server channel's name changes.

--- a/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerChannelChangeOverwrittenPermissionsListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerChannelChangeOverwrittenPermissionsListener.java
@@ -1,12 +1,22 @@
 package de.btobastian.javacord.listeners.server.channel;
 
 import de.btobastian.javacord.events.server.channel.ServerChannelChangeOverwrittenPermissionsEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
+import de.btobastian.javacord.listeners.server.role.RoleAttachableListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 
 /**
  * This listener listens to server channel overwritten permissions changes.
  */
 @FunctionalInterface
-public interface ServerChannelChangeOverwrittenPermissionsListener {
+public interface ServerChannelChangeOverwrittenPermissionsListener extends ServerAttachableListener,
+                                                                           UserAttachableListener,
+                                                                           ServerChannelAttachableListener,
+                                                                           RoleAttachableListener,
+                                                                           GloballyAttachableListener,
+                                                                           ObjectAttachableListener {
 
     /**
      * This method is called every time a server channel's overwritten permissions change.

--- a/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerChannelChangePositionListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerChannelChangePositionListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.server.channel;
 
 import de.btobastian.javacord.events.server.channel.ServerChannelChangePositionEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to server channel position changes.
  */
 @FunctionalInterface
-public interface ServerChannelChangePositionListener {
+public interface ServerChannelChangePositionListener extends ServerAttachableListener, ServerChannelAttachableListener,
+                                                             GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a server channel's position changes.

--- a/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerChannelCreateListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerChannelCreateListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.server.channel;
 
 import de.btobastian.javacord.events.server.channel.ServerChannelCreateEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to server channel creations.
  */
 @FunctionalInterface
-public interface ServerChannelCreateListener {
+public interface ServerChannelCreateListener extends ServerAttachableListener, GloballyAttachableListener,
+                                                     ObjectAttachableListener {
 
     /**
      * This method is called every time a server channel is created.

--- a/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerChannelDeleteListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerChannelDeleteListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.server.channel;
 
 import de.btobastian.javacord.events.server.channel.ServerChannelDeleteEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to server channel deletions.
  */
 @FunctionalInterface
-public interface ServerChannelDeleteListener {
+public interface ServerChannelDeleteListener extends ServerAttachableListener, ServerChannelAttachableListener,
+                                                     GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a server channel is deleted.

--- a/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerTextChannelAttachableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerTextChannelAttachableListener.java
@@ -1,0 +1,9 @@
+package de.btobastian.javacord.listeners.server.channel;
+
+import de.btobastian.javacord.entities.channels.ServerTextChannel;
+
+/**
+ * This is a marker interface for listeners that can be attached to a {@link ServerTextChannel}.
+ */
+public interface ServerTextChannelAttachableListener {
+}

--- a/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerTextChannelChangeTopicListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerTextChannelChangeTopicListener.java
@@ -1,12 +1,17 @@
 package de.btobastian.javacord.listeners.server.channel;
 
 import de.btobastian.javacord.events.server.channel.ServerTextChannelChangeTopicEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to server text channel topic changes.
  */
 @FunctionalInterface
-public interface ServerTextChannelChangeTopicListener {
+public interface ServerTextChannelChangeTopicListener extends ServerAttachableListener,
+                                                              ServerTextChannelAttachableListener,
+                                                              GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a server text channel's topic changes.

--- a/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerVoiceChannelAttachableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerVoiceChannelAttachableListener.java
@@ -1,0 +1,9 @@
+package de.btobastian.javacord.listeners.server.channel;
+
+import de.btobastian.javacord.entities.channels.ServerVoiceChannel;
+
+/**
+ * This is a marker interface for listeners that can be attached to a {@link ServerVoiceChannel}.
+ */
+public interface ServerVoiceChannelAttachableListener {
+}

--- a/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerVoiceChannelMemberJoinListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerVoiceChannelMemberJoinListener.java
@@ -1,12 +1,18 @@
 package de.btobastian.javacord.listeners.server.channel;
 
 import de.btobastian.javacord.events.server.channel.ServerVoiceChannelMemberJoinEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 
 /**
  * This listener listens to users joining a server voice channel.
  */
 @FunctionalInterface
-public interface ServerVoiceChannelMemberJoinListener {
+public interface ServerVoiceChannelMemberJoinListener extends ServerAttachableListener, UserAttachableListener,
+                                                              ServerVoiceChannelAttachableListener,
+                                                              GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a user joins a server voice channel.

--- a/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerVoiceChannelMemberLeaveListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/channel/ServerVoiceChannelMemberLeaveListener.java
@@ -1,12 +1,18 @@
 package de.btobastian.javacord.listeners.server.channel;
 
 import de.btobastian.javacord.events.server.channel.ServerVoiceChannelMemberLeaveEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 
 /**
  * This listener listens to users joining a server voice channel.
  */
 @FunctionalInterface
-public interface ServerVoiceChannelMemberLeaveListener {
+public interface ServerVoiceChannelMemberLeaveListener extends ServerAttachableListener, UserAttachableListener,
+                                                               ServerVoiceChannelAttachableListener,
+                                                               GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a user joins a server voice channel.

--- a/src/main/java/de/btobastian/javacord/listeners/server/emoji/CustomEmojiAttachableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/emoji/CustomEmojiAttachableListener.java
@@ -1,0 +1,9 @@
+package de.btobastian.javacord.listeners.server.emoji;
+
+import de.btobastian.javacord.entities.message.emoji.CustomEmoji;
+
+/**
+ * This is a marker interface for listeners that can be attached to a {@link CustomEmoji}.
+ */
+public interface CustomEmojiAttachableListener {
+}

--- a/src/main/java/de/btobastian/javacord/listeners/server/emoji/CustomEmojiChangeNameListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/emoji/CustomEmojiChangeNameListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.server.emoji;
 
 import de.btobastian.javacord.events.server.emoji.CustomEmojiChangeNameEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to custom emoji name changes.
  */
 @FunctionalInterface
-public interface CustomEmojiChangeNameListener {
+public interface CustomEmojiChangeNameListener extends ServerAttachableListener, CustomEmojiAttachableListener,
+                                                       GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a custom emoji's name changed.

--- a/src/main/java/de/btobastian/javacord/listeners/server/emoji/CustomEmojiCreateListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/emoji/CustomEmojiCreateListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.server.emoji;
 
 import de.btobastian.javacord.events.server.emoji.CustomEmojiCreateEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to custom emoji create event.
  */
 @FunctionalInterface
-public interface CustomEmojiCreateListener {
+public interface CustomEmojiCreateListener extends ServerAttachableListener, GloballyAttachableListener,
+                                                   ObjectAttachableListener {
 
     /**
      * This method is called every time a custom emoji is created.

--- a/src/main/java/de/btobastian/javacord/listeners/server/emoji/CustomEmojiDeleteListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/emoji/CustomEmojiDeleteListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.server.emoji;
 
 import de.btobastian.javacord.events.server.emoji.CustomEmojiDeleteEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to custom emoji delete event.
  */
 @FunctionalInterface
-public interface CustomEmojiDeleteListener {
+public interface CustomEmojiDeleteListener extends ServerAttachableListener, CustomEmojiAttachableListener,
+                                                   GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a custom emoji is deleted.

--- a/src/main/java/de/btobastian/javacord/listeners/server/member/ServerMemberBanListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/member/ServerMemberBanListener.java
@@ -1,12 +1,17 @@
 package de.btobastian.javacord.listeners.server.member;
 
 import de.btobastian.javacord.events.server.member.ServerMemberBanEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 
 /**
  * This listener listens to server member bans.
  */
 @FunctionalInterface
-public interface ServerMemberBanListener {
+public interface ServerMemberBanListener extends ServerAttachableListener, UserAttachableListener,
+                                                 GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a user got banned from a server.

--- a/src/main/java/de/btobastian/javacord/listeners/server/member/ServerMemberJoinListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/member/ServerMemberJoinListener.java
@@ -1,7 +1,11 @@
 package de.btobastian.javacord.listeners.server.member;
 
 import de.btobastian.javacord.events.server.member.ServerMemberJoinEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 import de.btobastian.javacord.listeners.server.ServerJoinListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 
 /**
  * This listener listens to server member joins.
@@ -9,7 +13,8 @@ import de.btobastian.javacord.listeners.server.ServerJoinListener;
  * ServerMemberAddListener is for other users and ServerJoinListener is for yourself!
  */
 @FunctionalInterface
-public interface ServerMemberJoinListener {
+public interface ServerMemberJoinListener extends ServerAttachableListener, UserAttachableListener,
+                                                  GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a user joins a server.

--- a/src/main/java/de/btobastian/javacord/listeners/server/member/ServerMemberLeaveListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/member/ServerMemberLeaveListener.java
@@ -1,7 +1,11 @@
 package de.btobastian.javacord.listeners.server.member;
 
 import de.btobastian.javacord.events.server.member.ServerMemberLeaveEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 import de.btobastian.javacord.listeners.server.ServerLeaveListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 
 /**
  * This listener listens to server member leaves.
@@ -9,12 +13,13 @@ import de.btobastian.javacord.listeners.server.ServerLeaveListener;
  * ServerMemberRemoveListener is for other users and ServerLeaveListener is for yourself!
  */
 @FunctionalInterface
-public interface ServerMemberLeaveListener {
+public interface ServerMemberLeaveListener extends ServerAttachableListener, UserAttachableListener,
+                                                   GloballyAttachableListener, ObjectAttachableListener {
 
     /**
-    * This method is called every time a user leaves a server.
-    *
-    * @param event the event.
-    */
+     * This method is called every time a user leaves a server.
+     *
+     * @param event the event.
+     */
     void onServerMemberLeave(ServerMemberLeaveEvent event);
 }

--- a/src/main/java/de/btobastian/javacord/listeners/server/member/ServerMemberUnbanListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/member/ServerMemberUnbanListener.java
@@ -1,12 +1,17 @@
 package de.btobastian.javacord.listeners.server.member;
 
 import de.btobastian.javacord.events.server.member.ServerMemberUnbanEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 
 /**
  * This listener listens to server member unbans.
  */
 @FunctionalInterface
-public interface ServerMemberUnbanListener {
+public interface ServerMemberUnbanListener extends ServerAttachableListener, UserAttachableListener,
+                                                   GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a user got unbanned from a server.

--- a/src/main/java/de/btobastian/javacord/listeners/server/role/RoleAttachableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/role/RoleAttachableListener.java
@@ -1,0 +1,9 @@
+package de.btobastian.javacord.listeners.server.role;
+
+import de.btobastian.javacord.entities.permissions.Role;
+
+/**
+ * This is a marker interface for listeners that can be attached to a {@link Role}.
+ */
+public interface RoleAttachableListener {
+}

--- a/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeColorListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeColorListener.java
@@ -1,12 +1,13 @@
 package de.btobastian.javacord.listeners.server.role;
 
 import de.btobastian.javacord.events.server.role.RoleChangeColorEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
 
 /**
  * This listener listens to role color changes.
  */
 @FunctionalInterface
-public interface RoleChangeColorListener {
+public interface RoleChangeColorListener extends GloballyAttachableListener {
 
     /**
      * This method is called every time a role's color changes.

--- a/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeColorListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeColorListener.java
@@ -2,12 +2,15 @@ package de.btobastian.javacord.listeners.server.role;
 
 import de.btobastian.javacord.events.server.role.RoleChangeColorEvent;
 import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to role color changes.
  */
 @FunctionalInterface
-public interface RoleChangeColorListener extends GloballyAttachableListener {
+public interface RoleChangeColorListener extends ServerAttachableListener, RoleAttachableListener,
+                                                 GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a role's color changes.

--- a/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeHoistListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeHoistListener.java
@@ -1,12 +1,13 @@
 package de.btobastian.javacord.listeners.server.role;
 
 import de.btobastian.javacord.events.server.role.RoleChangeHoistEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
 
 /**
  * This listener listens to role hoist changes.
  */
 @FunctionalInterface
-public interface RoleChangeHoistListener {
+public interface RoleChangeHoistListener extends GloballyAttachableListener {
 
     /**
      * This method is called every time a role's hoist changes.

--- a/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeHoistListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeHoistListener.java
@@ -2,12 +2,15 @@ package de.btobastian.javacord.listeners.server.role;
 
 import de.btobastian.javacord.events.server.role.RoleChangeHoistEvent;
 import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to role hoist changes.
  */
 @FunctionalInterface
-public interface RoleChangeHoistListener extends GloballyAttachableListener {
+public interface RoleChangeHoistListener extends ServerAttachableListener, RoleAttachableListener,
+                                                 GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a role's hoist changes.

--- a/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeManagedListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeManagedListener.java
@@ -1,12 +1,13 @@
 package de.btobastian.javacord.listeners.server.role;
 
 import de.btobastian.javacord.events.server.role.RoleChangeManagedEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
 
 /**
  * This listener listens to role managed flag changes.
  */
 @FunctionalInterface
-public interface RoleChangeManagedListener {
+public interface RoleChangeManagedListener extends GloballyAttachableListener {
 
     /**
      * This method is called every time a role's managed flag changes.

--- a/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeManagedListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeManagedListener.java
@@ -2,12 +2,15 @@ package de.btobastian.javacord.listeners.server.role;
 
 import de.btobastian.javacord.events.server.role.RoleChangeManagedEvent;
 import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to role managed flag changes.
  */
 @FunctionalInterface
-public interface RoleChangeManagedListener extends GloballyAttachableListener {
+public interface RoleChangeManagedListener extends ServerAttachableListener, RoleAttachableListener,
+                                                   GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a role's managed flag changes.

--- a/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeMentionableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeMentionableListener.java
@@ -1,12 +1,13 @@
 package de.btobastian.javacord.listeners.server.role;
 
 import de.btobastian.javacord.events.server.role.RoleChangeMentionableEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
 
 /**
  * This listener listens to role mentionable changes.
  */
 @FunctionalInterface
-public interface RoleChangeMentionableListener {
+public interface RoleChangeMentionableListener extends GloballyAttachableListener {
 
     /**
      * This method is called every time a role's mentionable flag changes.

--- a/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeMentionableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeMentionableListener.java
@@ -2,12 +2,15 @@ package de.btobastian.javacord.listeners.server.role;
 
 import de.btobastian.javacord.events.server.role.RoleChangeMentionableEvent;
 import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to role mentionable changes.
  */
 @FunctionalInterface
-public interface RoleChangeMentionableListener extends GloballyAttachableListener {
+public interface RoleChangeMentionableListener extends ServerAttachableListener, RoleAttachableListener,
+                                                       GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a role's mentionable flag changes.

--- a/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeNameListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeNameListener.java
@@ -1,12 +1,13 @@
 package de.btobastian.javacord.listeners.server.role;
 
 import de.btobastian.javacord.events.server.role.RoleChangeNameEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
 
 /**
  * This listener listens to role name changes.
  */
 @FunctionalInterface
-public interface RoleChangeNameListener {
+public interface RoleChangeNameListener extends GloballyAttachableListener {
 
     /**
      * This method is called every time a role's name changes.

--- a/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeNameListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangeNameListener.java
@@ -2,12 +2,15 @@ package de.btobastian.javacord.listeners.server.role;
 
 import de.btobastian.javacord.events.server.role.RoleChangeNameEvent;
 import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to role name changes.
  */
 @FunctionalInterface
-public interface RoleChangeNameListener extends GloballyAttachableListener {
+public interface RoleChangeNameListener extends ServerAttachableListener, RoleAttachableListener,
+                                                GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a role's name changes.

--- a/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangePermissionsListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangePermissionsListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.server.role;
 
 import de.btobastian.javacord.events.server.role.RoleChangePermissionsEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to role permission changes.
  */
 @FunctionalInterface
-public interface RoleChangePermissionsListener {
+public interface RoleChangePermissionsListener extends ServerAttachableListener, RoleAttachableListener,
+                                                       GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a role's permissions changes.

--- a/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangePositionListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/role/RoleChangePositionListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.server.role;
 
 import de.btobastian.javacord.events.server.role.RoleChangePositionEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to role position changes.
  */
 @FunctionalInterface
-public interface RoleChangePositionListener {
+public interface RoleChangePositionListener extends ServerAttachableListener, RoleAttachableListener,
+                                                    GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a role's position changes.

--- a/src/main/java/de/btobastian/javacord/listeners/server/role/RoleCreateListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/role/RoleCreateListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.server.role;
 
 import de.btobastian.javacord.events.server.role.RoleCreateEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to role creations.
  */
 @FunctionalInterface
-public interface RoleCreateListener {
+public interface RoleCreateListener extends ServerAttachableListener, GloballyAttachableListener,
+                                            ObjectAttachableListener {
 
     /**
      * This method is called every time a role is created.

--- a/src/main/java/de/btobastian/javacord/listeners/server/role/RoleDeleteListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/role/RoleDeleteListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.server.role;
 
 import de.btobastian.javacord.events.server.role.RoleDeleteEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to role deletions.
  */
 @FunctionalInterface
-public interface RoleDeleteListener {
+public interface RoleDeleteListener extends ServerAttachableListener, RoleAttachableListener,
+                                            GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a role is deleted.

--- a/src/main/java/de/btobastian/javacord/listeners/server/role/UserRoleAddListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/role/UserRoleAddListener.java
@@ -1,12 +1,17 @@
 package de.btobastian.javacord.listeners.server.role;
 
 import de.btobastian.javacord.events.server.role.UserRoleAddEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 
 /**
  * This listener listens to users being added to a role.
  */
 @FunctionalInterface
-public interface UserRoleAddListener {
+public interface UserRoleAddListener extends ServerAttachableListener, UserAttachableListener, RoleAttachableListener,
+                                             GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a user got added to a role.

--- a/src/main/java/de/btobastian/javacord/listeners/server/role/UserRoleRemoveListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/server/role/UserRoleRemoveListener.java
@@ -1,12 +1,18 @@
 package de.btobastian.javacord.listeners.server.role;
 
 import de.btobastian.javacord.events.server.role.UserRoleRemoveEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 
 /**
  * This listener listens to users being removed from a role.
  */
 @FunctionalInterface
-public interface UserRoleRemoveListener {
+public interface UserRoleRemoveListener extends ServerAttachableListener, UserAttachableListener,
+                                                RoleAttachableListener, GloballyAttachableListener,
+                                                ObjectAttachableListener {
 
     /**
      * This method is called every time a user got removed from a role.

--- a/src/main/java/de/btobastian/javacord/listeners/user/UserAttachableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/user/UserAttachableListener.java
@@ -1,0 +1,9 @@
+package de.btobastian.javacord.listeners.user;
+
+import de.btobastian.javacord.entities.User;
+
+/**
+ * This is a marker interface for listeners that can be attached to a {@link User}.
+ */
+public interface UserAttachableListener {
+}

--- a/src/main/java/de/btobastian/javacord/listeners/user/UserChangeActivityListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/user/UserChangeActivityListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.user;
 
 import de.btobastian.javacord.events.user.UserChangeActivityEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to user activity changes.
  */
 @FunctionalInterface
-public interface UserChangeActivityListener {
+public interface UserChangeActivityListener extends ServerAttachableListener, UserAttachableListener,
+                                                    GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a user changed their activity.

--- a/src/main/java/de/btobastian/javacord/listeners/user/UserChangeAvatarListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/user/UserChangeAvatarListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.user;
 
 import de.btobastian.javacord.events.user.UserChangeAvatarEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to user avatar changes.
  */
 @FunctionalInterface
-public interface UserChangeAvatarListener {
+public interface UserChangeAvatarListener extends ServerAttachableListener, UserAttachableListener,
+                                                  GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a user changed their avatar.

--- a/src/main/java/de/btobastian/javacord/listeners/user/UserChangeNameListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/user/UserChangeNameListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.user;
 
 import de.btobastian.javacord.events.user.UserChangeNameEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to user name changes.
  */
 @FunctionalInterface
-public interface UserChangeNameListener {
+public interface UserChangeNameListener extends ServerAttachableListener, UserAttachableListener,
+                                                GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a user changed their name.

--- a/src/main/java/de/btobastian/javacord/listeners/user/UserChangeNicknameListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/user/UserChangeNicknameListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.user;
 
 import de.btobastian.javacord.events.user.UserChangeNicknameEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to user nickname changes.
  */
 @FunctionalInterface
-public interface UserChangeNicknameListener {
+public interface UserChangeNicknameListener extends ServerAttachableListener, UserAttachableListener,
+                                                    GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a user changed their nickname on a server.

--- a/src/main/java/de/btobastian/javacord/listeners/user/UserChangeStatusListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/user/UserChangeStatusListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.user;
 
 import de.btobastian.javacord.events.user.UserChangeStatusEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to user status changes.
  */
 @FunctionalInterface
-public interface UserChangeStatusListener {
+public interface UserChangeStatusListener extends ServerAttachableListener, UserAttachableListener,
+                                                  GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a user changed their status.

--- a/src/main/java/de/btobastian/javacord/listeners/user/UserStartTypingListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/user/UserStartTypingListener.java
@@ -2,6 +2,10 @@ package de.btobastian.javacord.listeners.user;
 
 
 import de.btobastian.javacord.events.user.UserStartTypingEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.TextChannelAttachableListener;
+import de.btobastian.javacord.listeners.server.ServerAttachableListener;
 
 /**
  * This listener listens to users typing.
@@ -9,7 +13,9 @@ import de.btobastian.javacord.events.user.UserStartTypingEvent;
  * It also stops if the user sent a message.
  */
 @FunctionalInterface
-public interface UserStartTypingListener {
+public interface UserStartTypingListener extends ServerAttachableListener, UserAttachableListener,
+                                                 TextChannelAttachableListener, GloballyAttachableListener,
+                                                 ObjectAttachableListener {
 
     /**
      * This method is called every time a user started typing.

--- a/src/main/java/de/btobastian/javacord/listeners/user/channel/PrivateChannelAttachableListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/user/channel/PrivateChannelAttachableListener.java
@@ -1,0 +1,9 @@
+package de.btobastian.javacord.listeners.user.channel;
+
+import de.btobastian.javacord.entities.channels.PrivateChannel;
+
+/**
+ * This is a marker interface for listeners that can be attached to a {@link PrivateChannel}.
+ */
+public interface PrivateChannelAttachableListener {
+}

--- a/src/main/java/de/btobastian/javacord/listeners/user/channel/PrivateChannelCreateListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/user/channel/PrivateChannelCreateListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.user.channel;
 
 import de.btobastian.javacord.events.user.channel.PrivateChannelCreateEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 
 /**
  * This listener listens to private channel creations.
  */
 @FunctionalInterface
-public interface PrivateChannelCreateListener {
+public interface PrivateChannelCreateListener extends UserAttachableListener, GloballyAttachableListener,
+                                                      ObjectAttachableListener {
 
     /**
      * This method is called every time a private channel is created.

--- a/src/main/java/de/btobastian/javacord/listeners/user/channel/PrivateChannelDeleteListener.java
+++ b/src/main/java/de/btobastian/javacord/listeners/user/channel/PrivateChannelDeleteListener.java
@@ -1,12 +1,16 @@
 package de.btobastian.javacord.listeners.user.channel;
 
 import de.btobastian.javacord.events.user.channel.PrivateChannelDeleteEvent;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
+import de.btobastian.javacord.listeners.user.UserAttachableListener;
 
 /**
  * This listener listens to private channel deletions.
  */
 @FunctionalInterface
-public interface PrivateChannelDeleteListener {
+public interface PrivateChannelDeleteListener extends UserAttachableListener, PrivateChannelAttachableListener,
+                                                      GloballyAttachableListener, ObjectAttachableListener {
 
     /**
      * This method is called every time a private channel is deleted.

--- a/src/main/java/de/btobastian/javacord/utils/ClassHelper.java
+++ b/src/main/java/de/btobastian/javacord/utils/ClassHelper.java
@@ -1,0 +1,86 @@
+package de.btobastian.javacord.utils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * This class contains some helpers to handle classes.
+ */
+public class ClassHelper {
+
+    private ClassHelper() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Get all interfaces of the given class including extended interfaces and interfaces of all superclasses.
+     * If the given class is an interface, it will be included in the result, otherwise not.
+     *
+     * @param clazz The class to get the interfaces for.
+     * @return The interfaces of the given class.
+     */
+    public static List<Class<?>> getInterfaces(Class<?> clazz) {
+        return getInterfacesAsStream(clazz).collect(Collectors.toList());
+    }
+
+    /**
+     * Get a stream of all interfaces of the given class including extended interfaces and interfaces of all
+     * superclasses.
+     * If the given class is an interface, it will be included in the result, otherwise not.
+     *
+     * @param clazz The class to get the interfaces for.
+     * @return The stream of interfaces of the given class.
+     */
+    public static Stream<Class<?>> getInterfacesAsStream(Class<?> clazz) {
+        return getSuperclassesAsStream(clazz, true)
+                .flatMap(superClass -> Stream.concat(
+                        superClass.isInterface() ? Stream.of(superClass) : Stream.empty(),
+                        Arrays.stream(superClass.getInterfaces()).flatMap(ClassHelper::getInterfacesAsStream)))
+                .distinct();
+    }
+
+    /**
+     * Get all superclasses of the given class.
+     * If the given class is an interface, the result will be empty.
+     * The given class will not be included in the result.
+     *
+     * @param clazz The class to get the superclasses for.
+     * @return The superclasses of the given class.
+     */
+    public static List<Class<?>> getSuperclasses(Class<?> clazz) {
+        return getSuperclassesAsStream(clazz).collect(Collectors.toList());
+    }
+
+    /**
+     * Get a stream of all superclasses of the given class.
+     * If the given class is an interface, the result will be empty.
+     * The given class will not be included in the result.
+     *
+     * @param clazz The class to get the superclasses for.
+     * @return The stream of superclasses of the given class.
+     */
+    public static Stream<Class<?>> getSuperclassesAsStream(Class<?> clazz) {
+        return getSuperclassesAsStream(clazz, false);
+    }
+
+    /**
+     * Get a stream of all superclasses of the given class.
+     * If the given class is an interface, the result will be empty, except if {@code includeArgument} is {@code true}.
+     * Whether the given class will be included in the result is controlled via the parameter {@code includeArgument}.
+     *
+     * @param clazz The class to get the superclasses for.
+     * @param includeArgument Whether to include the given class in the result.
+     * @return The stream of superclasses of the given class.
+     */
+    private static Stream<Class<?>> getSuperclassesAsStream(Class<?> clazz, boolean includeArgument) {
+        return Stream.concat(includeArgument ? Stream.of(clazz) : Stream.empty(),
+                             Optional.ofNullable(clazz.getSuperclass())
+                                     .map(Stream::of)
+                                     .orElseGet(Stream::empty)
+                                     .flatMap(superclass -> getSuperclassesAsStream(superclass, true)));
+    }
+
+}

--- a/src/main/java/de/btobastian/javacord/utils/ListenerManager.java
+++ b/src/main/java/de/btobastian/javacord/utils/ListenerManager.java
@@ -2,6 +2,8 @@ package de.btobastian.javacord.utils;
 
 import de.btobastian.javacord.DiscordApi;
 import de.btobastian.javacord.ImplDiscordApi;
+import de.btobastian.javacord.listeners.GloballyAttachableListener;
+import de.btobastian.javacord.listeners.ObjectAttachableListener;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -86,6 +88,15 @@ public class ListenerManager<T> {
     }
 
     /**
+     * Gets the listener class context for the managed listener.
+     *
+     * @return The listener class context for the managed listener.
+     */
+    public Class<T> getListenerClass() {
+        return listenerClass;
+    }
+
+    /**
      * Gets the managed listener.
      *
      * @return The managed listener.
@@ -129,11 +140,15 @@ public class ListenerManager<T> {
      *
      * @return The current instance in order to chain call methods.
      */
+    @SuppressWarnings("unchecked")
     public ListenerManager<T> remove() {
         if (isGlobalListener()) {
-            api.removeListener(listenerClass, listener);
+            api.removeListener(
+                    (Class<GloballyAttachableListener>) listenerClass, (GloballyAttachableListener) listener);
         } else {
-            api.removeObjectListener(assignedObjectClass, objectId, listenerClass, listener);
+            api.removeObjectListener(
+                    assignedObjectClass, objectId, (Class<ObjectAttachableListener>) listenerClass,
+                    (ObjectAttachableListener) listener);
         }
         return this;
     }

--- a/src/main/java/de/btobastian/javacord/utils/ListenerManager.java
+++ b/src/main/java/de/btobastian/javacord/utils/ListenerManager.java
@@ -96,15 +96,12 @@ public class ListenerManager<T> {
 
     /**
      * Gets the class of the object, the listener was added to.
-     * For global listeners, it returns the class of {@link DiscordApi}.
+     * For global listeners, it returns an empty {@code Optional}.
      *
      * @return The class of the object, the listener was added to.
      */
-    public Class<?> getAssignedObjectClass() {
-        if (isGlobalListener()) {
-            return DiscordApi.class;
-        }
-        return assignedObjectClass;
+    public Optional<Class<?>> getAssignedObjectClass() {
+        return Optional.ofNullable(assignedObjectClass);
     }
 
     /**

--- a/src/main/java/de/btobastian/javacord/utils/ListenerManager.java
+++ b/src/main/java/de/btobastian/javacord/utils/ListenerManager.java
@@ -118,12 +118,18 @@ public class ListenerManager<T> {
     }
 
     /**
+     * Called when the listener is removed.
+     */
+    public void removed() {
+        removeHandlers.forEach(Runnable::run);
+    }
+
+    /**
      * Removes the listener.
      *
      * @return The current instance in order to chain call methods.
      */
     public ListenerManager<T> remove() {
-        removeHandlers.forEach(Runnable::run);
         if (isGlobalListener()) {
             api.removeListener(listenerClass, listener);
         } else {

--- a/src/main/java/de/btobastian/javacord/utils/handler/message/MessageDeleteBulkHandler.java
+++ b/src/main/java/de/btobastian/javacord/utils/handler/message/MessageDeleteBulkHandler.java
@@ -3,6 +3,7 @@ package de.btobastian.javacord.utils.handler.message;
 import com.fasterxml.jackson.databind.JsonNode;
 import de.btobastian.javacord.DiscordApi;
 import de.btobastian.javacord.entities.channels.ServerTextChannel;
+import de.btobastian.javacord.entities.message.Message;
 import de.btobastian.javacord.events.message.MessageDeleteEvent;
 import de.btobastian.javacord.listeners.message.MessageDeleteListener;
 import de.btobastian.javacord.utils.PacketHandler;
@@ -38,7 +39,7 @@ public class MessageDeleteBulkHandler extends PacketHandler {
                 api.getCachedMessageById(messageId)
                         .ifPresent(((ImplMessageCache) channel.getMessageCache())::removeMessage);
                 api.removeMessageFromCache(messageId);
-                listeners.addAll(api.getMessageDeleteListeners(messageId));
+                listeners.addAll(Message.getMessageDeleteListeners(api, messageId));
                 listeners.addAll(channel.getMessageDeleteListeners());
                 if (channel instanceof ServerTextChannel) {
                     listeners.addAll(((ServerTextChannel) channel).getServer().getMessageDeleteListeners());

--- a/src/main/java/de/btobastian/javacord/utils/handler/message/MessageDeleteHandler.java
+++ b/src/main/java/de/btobastian/javacord/utils/handler/message/MessageDeleteHandler.java
@@ -3,6 +3,7 @@ package de.btobastian.javacord.utils.handler.message;
 import com.fasterxml.jackson.databind.JsonNode;
 import de.btobastian.javacord.DiscordApi;
 import de.btobastian.javacord.entities.channels.ServerTextChannel;
+import de.btobastian.javacord.entities.message.Message;
 import de.btobastian.javacord.events.message.MessageDeleteEvent;
 import de.btobastian.javacord.listeners.message.MessageDeleteListener;
 import de.btobastian.javacord.utils.PacketHandler;
@@ -37,7 +38,7 @@ public class MessageDeleteHandler extends PacketHandler {
             api.getCachedMessageById(messageId)
                     .ifPresent(((ImplMessageCache) channel.getMessageCache())::removeMessage);
             api.removeMessageFromCache(messageId);
-            listeners.addAll(api.getMessageDeleteListeners(messageId));
+            listeners.addAll(Message.getMessageDeleteListeners(api, messageId));
             listeners.addAll(channel.getMessageDeleteListeners());
             if (channel instanceof ServerTextChannel) {
                 listeners.addAll(((ServerTextChannel) channel).getServer().getMessageDeleteListeners());

--- a/src/main/java/de/btobastian/javacord/utils/handler/message/MessageUpdateHandler.java
+++ b/src/main/java/de/btobastian/javacord/utils/handler/message/MessageUpdateHandler.java
@@ -125,7 +125,7 @@ public class MessageUpdateHandler extends PacketHandler {
      */
     private void dispatchEditEvent(MessageEditEvent event) {
         List<MessageEditListener> listeners = new ArrayList<>();
-        listeners.addAll(api.getMessageEditListeners(event.getMessageId()));
+        listeners.addAll(Message.getMessageEditListeners(api, event.getMessageId()));
         listeners.addAll(event.getChannel().getMessageEditListeners());
         if (event.getChannel() instanceof ServerTextChannel) {
             listeners.addAll(((ServerTextChannel) event.getChannel()).getServer().getMessageEditListeners());

--- a/src/main/java/de/btobastian/javacord/utils/handler/message/reaction/MessageReactionAddHandler.java
+++ b/src/main/java/de/btobastian/javacord/utils/handler/message/reaction/MessageReactionAddHandler.java
@@ -50,7 +50,7 @@ public class MessageReactionAddHandler extends PacketHandler {
             ReactionAddEvent event = new ReactionAddEvent(api, messageId, channel, emoji, user);
 
             List<ReactionAddListener> listeners = new ArrayList<>();
-            listeners.addAll(api.getReactionAddListeners(messageId));
+            listeners.addAll(Message.getReactionAddListeners(api, messageId));
             listeners.addAll(channel.getReactionAddListeners());
             if (channel instanceof ServerTextChannel) {
                 listeners.addAll(((ServerTextChannel) channel).getServer().getReactionAddListeners());

--- a/src/main/java/de/btobastian/javacord/utils/handler/message/reaction/MessageReactionRemoveAllHandler.java
+++ b/src/main/java/de/btobastian/javacord/utils/handler/message/reaction/MessageReactionRemoveAllHandler.java
@@ -38,7 +38,7 @@ public class MessageReactionRemoveAllHandler extends PacketHandler {
             ReactionRemoveAllEvent event = new ReactionRemoveAllEvent(api, messageId, channel);
 
             List<ReactionRemoveAllListener> listeners = new ArrayList<>();
-            listeners.addAll(api.getReactionRemoveAllListeners(messageId));
+            listeners.addAll(Message.getReactionRemoveAllListeners(api, messageId));
             listeners.addAll(channel.getReactionRemoveAllListeners());
             if (channel instanceof ServerTextChannel) {
                 listeners.addAll(((ServerTextChannel) channel).getServer().getReactionRemoveAllListeners());

--- a/src/main/java/de/btobastian/javacord/utils/handler/message/reaction/MessageReactionRemoveHandler.java
+++ b/src/main/java/de/btobastian/javacord/utils/handler/message/reaction/MessageReactionRemoveHandler.java
@@ -50,7 +50,7 @@ public class MessageReactionRemoveHandler extends PacketHandler {
             ReactionRemoveEvent event = new ReactionRemoveEvent(api, messageId, channel, emoji, user);
 
             List<ReactionRemoveListener> listeners = new ArrayList<>();
-            listeners.addAll(api.getReactionRemoveListeners(messageId));
+            listeners.addAll(Message.getReactionRemoveListeners(api, messageId));
             listeners.addAll(channel.getReactionRemoveListeners());
             if (channel instanceof ServerTextChannel) {
                 listeners.addAll(((ServerTextChannel) channel).getServer().getReactionRemoveListeners());

--- a/src/main/java/de/btobastian/javacord/utils/handler/server/role/GuildRoleUpdateHandler.java
+++ b/src/main/java/de/btobastian/javacord/utils/handler/server/role/GuildRoleUpdateHandler.java
@@ -9,12 +9,14 @@ import de.btobastian.javacord.events.server.role.RoleChangeColorEvent;
 import de.btobastian.javacord.events.server.role.RoleChangeHoistEvent;
 import de.btobastian.javacord.events.server.role.RoleChangeManagedEvent;
 import de.btobastian.javacord.events.server.role.RoleChangeMentionableEvent;
+import de.btobastian.javacord.events.server.role.RoleChangeNameEvent;
 import de.btobastian.javacord.events.server.role.RoleChangePermissionsEvent;
 import de.btobastian.javacord.events.server.role.RoleChangePositionEvent;
 import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeManagedListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeMentionableListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeNameListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.utils.PacketHandler;
@@ -102,6 +104,21 @@ public class GuildRoleUpdateHandler extends PacketHandler {
                 listeners.addAll(api.getRoleChangeMentionableListeners());
 
                 dispatchEvent(listeners, listener -> listener.onRoleChangeMentionable(event));
+            }
+
+            String oldName = role.getName();
+            String newName = roleJson.get("name").asText();
+            if (!oldName.equals(newName)) {
+                role.setName(newName);
+
+                RoleChangeNameEvent event = new RoleChangeNameEvent(api, role, newName, oldName);
+
+                List<RoleChangeNameListener> listeners = new ArrayList<>();
+                listeners.addAll(role.getRoleChangeNameListeners());
+                listeners.addAll(role.getServer().getRoleChangeNameListeners());
+                listeners.addAll(api.getRoleChangeNameListeners());
+
+                dispatchEvent(listeners, listener -> listener.onRoleChangeName(event));
             }
 
             Permissions oldPermissions = role.getPermissions();

--- a/src/main/java/de/btobastian/javacord/utils/handler/server/role/GuildRoleUpdateHandler.java
+++ b/src/main/java/de/btobastian/javacord/utils/handler/server/role/GuildRoleUpdateHandler.java
@@ -6,9 +6,11 @@ import de.btobastian.javacord.entities.permissions.Permissions;
 import de.btobastian.javacord.entities.permissions.impl.ImplPermissions;
 import de.btobastian.javacord.entities.permissions.impl.ImplRole;
 import de.btobastian.javacord.events.server.role.RoleChangeColorEvent;
+import de.btobastian.javacord.events.server.role.RoleChangeHoistEvent;
 import de.btobastian.javacord.events.server.role.RoleChangePermissionsEvent;
 import de.btobastian.javacord.events.server.role.RoleChangePositionEvent;
 import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.utils.PacketHandler;
@@ -51,6 +53,21 @@ public class GuildRoleUpdateHandler extends PacketHandler {
                 listeners.addAll(api.getRoleChangeColorListeners());
 
                 dispatchEvent(listeners, listener -> listener.onRoleChangeColor(event));
+            }
+
+            boolean oldHoist = role.isDisplayedSeparately();
+            boolean newHoist = roleJson.get("hoist").asBoolean(false);
+            if (oldHoist != newHoist) {
+                role.setHoist(newHoist);
+
+                RoleChangeHoistEvent event = new RoleChangeHoistEvent(api, role, oldHoist);
+
+                List<RoleChangeHoistListener> listeners = new ArrayList<>();
+                listeners.addAll(role.getRoleChangeHoistListeners());
+                listeners.addAll(role.getServer().getRoleChangeHoistListeners());
+                listeners.addAll(api.getRoleChangeHoistListeners());
+
+                dispatchEvent(listeners, listener -> listener.onRoleChangeHoist(event));
             }
 
             Permissions oldPermissions = role.getPermissions();

--- a/src/main/java/de/btobastian/javacord/utils/handler/server/role/GuildRoleUpdateHandler.java
+++ b/src/main/java/de/btobastian/javacord/utils/handler/server/role/GuildRoleUpdateHandler.java
@@ -7,10 +7,12 @@ import de.btobastian.javacord.entities.permissions.impl.ImplPermissions;
 import de.btobastian.javacord.entities.permissions.impl.ImplRole;
 import de.btobastian.javacord.events.server.role.RoleChangeColorEvent;
 import de.btobastian.javacord.events.server.role.RoleChangeHoistEvent;
+import de.btobastian.javacord.events.server.role.RoleChangeManagedEvent;
 import de.btobastian.javacord.events.server.role.RoleChangePermissionsEvent;
 import de.btobastian.javacord.events.server.role.RoleChangePositionEvent;
 import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeManagedListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.utils.PacketHandler;
@@ -68,6 +70,21 @@ public class GuildRoleUpdateHandler extends PacketHandler {
                 listeners.addAll(api.getRoleChangeHoistListeners());
 
                 dispatchEvent(listeners, listener -> listener.onRoleChangeHoist(event));
+            }
+
+            boolean oldManaged = role.isManaged();
+            boolean newManaged = roleJson.get("managed").asBoolean(false);
+            if (oldManaged != newManaged) {
+                role.setManaged(newManaged);
+
+                RoleChangeManagedEvent event = new RoleChangeManagedEvent(api, role, oldManaged);
+
+                List<RoleChangeManagedListener> listeners = new ArrayList<>();
+                listeners.addAll(role.getRoleChangeManagedListeners());
+                listeners.addAll(role.getServer().getRoleChangeManagedListeners());
+                listeners.addAll(api.getRoleChangeManagedListeners());
+
+                dispatchEvent(listeners, listener -> listener.onRoleChangeManaged(event));
             }
 
             Permissions oldPermissions = role.getPermissions();

--- a/src/main/java/de/btobastian/javacord/utils/handler/server/role/GuildRoleUpdateHandler.java
+++ b/src/main/java/de/btobastian/javacord/utils/handler/server/role/GuildRoleUpdateHandler.java
@@ -8,11 +8,13 @@ import de.btobastian.javacord.entities.permissions.impl.ImplRole;
 import de.btobastian.javacord.events.server.role.RoleChangeColorEvent;
 import de.btobastian.javacord.events.server.role.RoleChangeHoistEvent;
 import de.btobastian.javacord.events.server.role.RoleChangeManagedEvent;
+import de.btobastian.javacord.events.server.role.RoleChangeMentionableEvent;
 import de.btobastian.javacord.events.server.role.RoleChangePermissionsEvent;
 import de.btobastian.javacord.events.server.role.RoleChangePositionEvent;
 import de.btobastian.javacord.listeners.server.role.RoleChangeColorListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeHoistListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangeManagedListener;
+import de.btobastian.javacord.listeners.server.role.RoleChangeMentionableListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePermissionsListener;
 import de.btobastian.javacord.listeners.server.role.RoleChangePositionListener;
 import de.btobastian.javacord.utils.PacketHandler;
@@ -85,6 +87,21 @@ public class GuildRoleUpdateHandler extends PacketHandler {
                 listeners.addAll(api.getRoleChangeManagedListeners());
 
                 dispatchEvent(listeners, listener -> listener.onRoleChangeManaged(event));
+            }
+
+            boolean oldMentionable = role.isMentionable();
+            boolean newMentionable = roleJson.get("mentionable").asBoolean(false);
+            if (oldMentionable != newMentionable) {
+                role.setMentionable(newMentionable);
+
+                RoleChangeMentionableEvent event = new RoleChangeMentionableEvent(api, role, oldMentionable);
+
+                List<RoleChangeMentionableListener> listeners = new ArrayList<>();
+                listeners.addAll(role.getRoleChangeMentionableListeners());
+                listeners.addAll(role.getServer().getRoleChangeMentionableListeners());
+                listeners.addAll(api.getRoleChangeMentionableListeners());
+
+                dispatchEvent(listeners, listener -> listener.onRoleChangeMentionable(event));
             }
 
             Permissions oldPermissions = role.getPermissions();


### PR DESCRIPTION
- Remove unnecessary class parameters for listener registration methods
- Do not register listeners multiple times to the same context and always use the same listener manager, which now also gets its remove handlers invoked whenever the listener is removed from its context, not only when removed through the listener manager
- Add DiscordApi#removeObjectListener and DiscordApi#removeListener