### PR TITLE
Replace Magic Numbers

### DIFF
--- a/src/main/java/de/btobastian/javacord/entities/impl/ImplServer.java
+++ b/src/main/java/de/btobastian/javacord/entities/impl/ImplServer.java
@@ -26,6 +26,7 @@ import de.btobastian.javacord.entities.message.emoji.CustomEmoji;
 import de.btobastian.javacord.entities.permissions.Role;
 import de.btobastian.javacord.entities.permissions.impl.ImplRole;
 import de.btobastian.javacord.utils.Cleanupable;
+import de.btobastian.javacord.utils.GatewayOpcode;
 import de.btobastian.javacord.utils.logging.LoggerUtil;
 import org.slf4j.Logger;
 
@@ -196,7 +197,7 @@ public class ImplServer implements Server, Cleanupable {
 
         if (isLarge() && getMembers().size() < getMemberCount()) {
             ObjectNode requestGuildMembersPacket = JsonNodeFactory.instance.objectNode()
-                    .put("op", 8);
+                    .put("op", GatewayOpcode.REQUEST_GUILD_MEMBERS.getCode());
             requestGuildMembersPacket.putObject("d")
                             .put("guild_id", String.valueOf(getId()))
                             .put("query","")

--- a/src/main/java/de/btobastian/javacord/utils/GatewayOpcode.java
+++ b/src/main/java/de/btobastian/javacord/utils/GatewayOpcode.java
@@ -1,0 +1,120 @@
+package de.btobastian.javacord.utils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * An enum with all gateway opcode as defined by
+ * <a href="https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-opcodes">Discord</a>.
+ */
+public enum GatewayOpcode {
+
+    /**
+     * dispatches an event
+     */
+    DISPATCH(0),
+
+    /**
+     * used for ping checking
+     */
+    HEARTBEAT(1),
+
+    /**
+     * used for client handshake
+     */
+    IDENTIFY(2),
+
+    /**
+     * used to update the client status
+     */
+    STATUS_UPDATE(3),
+
+    /**
+     * used to join/move/leave voice channels
+     */
+    VOICE_STATE_UPDATE(4),
+
+    /**
+     * used for voice ping checking
+     */
+    VOICE_SERVER_PING(5),
+
+    /**
+     * used to resume a closed connection
+     */
+    RESUME(6),
+
+    /**
+     * used to tell clients to reconnect to the gateway
+     */
+    RECONNECT(7),
+
+    /**
+     * used to request guild members
+     */
+    REQUEST_GUILD_MEMBERS(8),
+
+    /**
+     * used to notify client they have an invalid session id
+     */
+    INVALID_SESSION(9),
+
+    /**
+     * sent immediately after connecting, contains heartbeat and server debug information
+     */
+    HELLO(10),
+
+    /**
+     * sent immediately following a client heartbeat that was received
+     */
+    HEARTBEAT_ACK(11);
+
+    /**
+     * A map for retrieving the enum instances by code.
+     */
+    private static final Map<Integer, GatewayOpcode> instanceByCode;
+
+    /**
+     * The actual numeric code
+     */
+    private final int code;
+
+    static {
+        instanceByCode = Collections.unmodifiableMap(
+                Arrays.stream(values())
+                        .collect(Collectors.toMap(GatewayOpcode::getCode, Function.identity())));
+    }
+
+    /**
+     * Creates a new gateway opcode.
+     *
+     * @param code The actual numeric code.
+     */
+    GatewayOpcode(int code) {
+        this.code = code;
+    }
+
+    /**
+     * Gets the gateway opcode by actual numeric code.
+     *
+     * @param code The actual numeric code.
+     * @return The gateway opcode with the actual numeric code.
+     */
+    public static Optional<GatewayOpcode> fromCode(int code) {
+        return Optional.ofNullable(instanceByCode.get(code));
+    }
+
+    /**
+     * Gets the actual numeric code.
+     *
+     * @return The actual numeric code.
+     */
+    public int getCode() {
+        return code;
+    }
+
+}

--- a/src/main/java/de/btobastian/javacord/utils/VoiceGatewayOpcode.java
+++ b/src/main/java/de/btobastian/javacord/utils/VoiceGatewayOpcode.java
@@ -1,0 +1,115 @@
+package de.btobastian.javacord.utils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * An enum with all voice gateway opcode as defined by
+ * <a href="https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#voice-voice-opcodes">Discord</a>.
+ */
+public enum VoiceGatewayOpcode {
+
+    /**
+     * begin a voice websocket connection
+     */
+    IDENTIFY(0),
+
+    /**
+     * select the voice protocol
+     */
+    SELECT_PROTOCOL(1),
+
+    /**
+     * complete the websocket handshake
+     */
+    READY(2),
+
+    /**
+     * keep the websocket connection alive
+     */
+    HEARTBEAT(3),
+
+    /**
+     * describe the session
+     */
+    SESSION_DESCRIPTION(4),
+
+    /**
+     * indicate which users are speaking
+     */
+    SPEAKING(5),
+
+    /**
+     * sent immediately following a received client heartbeat
+     */
+    HEARTBEAT_ACK(6),
+
+    /**
+     * resume a connection
+     */
+    RESUME(7),
+
+    /**
+     * the continuous interval in milliseconds after which the client should send a heartbeat
+     */
+    HELLO(8),
+
+    /**
+     * acknowledge Resume
+     */
+    RESUMED(9),
+
+    /**
+     * a client has disconnected from the voice channel
+     */
+    CLIENT_DISCONNECT(13);
+
+    /**
+     * A map for retrieving the enum instances by code.
+     */
+    private static final Map<Integer, VoiceGatewayOpcode> instanceByCode;
+
+    /**
+     * The actual numeric code
+     */
+    private final int code;
+
+    static {
+        instanceByCode = Collections.unmodifiableMap(
+                Arrays.stream(values())
+                        .collect(Collectors.toMap(VoiceGatewayOpcode::getCode, Function.identity())));
+    }
+
+    /**
+     * Creates a new voice gateway opcode.
+     *
+     * @param code The actual numeric code.
+     */
+    VoiceGatewayOpcode(int code) {
+        this.code = code;
+    }
+
+    /**
+     * Gets the voice gateway opcode by actual numeric code.
+     *
+     * @param code The actual numeric code.
+     * @return The voice gateway opcode with the actual numeric code.
+     */
+    public static Optional<VoiceGatewayOpcode> fromCode(int code) {
+        return Optional.ofNullable(instanceByCode.get(code));
+    }
+
+    /**
+     * Gets the actual numeric code.
+     *
+     * @return The actual numeric code.
+     */
+    public int getCode() {
+        return code;
+    }
+
+}

--- a/src/main/java/de/btobastian/javacord/utils/WebSocketCloseCode.java
+++ b/src/main/java/de/btobastian/javacord/utils/WebSocketCloseCode.java
@@ -23,7 +23,7 @@ public enum WebSocketCloseCode {
      * which the connection was established has been fulfilled.
      * </i>
      */
-    NORMAL(com.neovisionaries.ws.client.WebSocketCloseCode.NORMAL),
+    NORMAL(com.neovisionaries.ws.client.WebSocketCloseCode.NORMAL, Usage.BOTH),
 
     /**
      * 1001;
@@ -32,7 +32,7 @@ public enum WebSocketCloseCode {
      * going down or a browser having navigated away from a page.
      * </i>
      */
-    AWAY(com.neovisionaries.ws.client.WebSocketCloseCode.AWAY),
+    AWAY(com.neovisionaries.ws.client.WebSocketCloseCode.AWAY, Usage.BOTH),
 
     /**
      * 1002;
@@ -41,7 +41,7 @@ public enum WebSocketCloseCode {
      * to a protocol error.
      * </i>
      */
-    UNCONFORMED(com.neovisionaries.ws.client.WebSocketCloseCode.UNCONFORMED),
+    UNCONFORMED(com.neovisionaries.ws.client.WebSocketCloseCode.UNCONFORMED, Usage.BOTH),
 
     /**
      * 1003;
@@ -52,7 +52,7 @@ public enum WebSocketCloseCode {
      * send this if it receives a binary message).
      * </i>
      */
-    UNACCEPTABLE(com.neovisionaries.ws.client.WebSocketCloseCode.UNACCEPTABLE),
+    UNACCEPTABLE(com.neovisionaries.ws.client.WebSocketCloseCode.UNACCEPTABLE, Usage.BOTH),
 
     /**
      * 1005;
@@ -63,7 +63,7 @@ public enum WebSocketCloseCode {
      * code was actually present.
      * </i>
      */
-    NONE(com.neovisionaries.ws.client.WebSocketCloseCode.NONE),
+    NONE(com.neovisionaries.ws.client.WebSocketCloseCode.NONE, Usage.BOTH),
 
     /**
      * 1006;
@@ -75,7 +75,7 @@ public enum WebSocketCloseCode {
      * receiving a Close control frame.
      * </i>
      */
-    ABNORMAL(com.neovisionaries.ws.client.WebSocketCloseCode.ABNORMAL),
+    ABNORMAL(com.neovisionaries.ws.client.WebSocketCloseCode.ABNORMAL, Usage.BOTH),
 
     /**
      * 1007;
@@ -87,7 +87,7 @@ public enum WebSocketCloseCode {
      * within a text message).
      * </i>
      */
-    INCONSISTENT(com.neovisionaries.ws.client.WebSocketCloseCode.INCONSISTENT),
+    INCONSISTENT(com.neovisionaries.ws.client.WebSocketCloseCode.INCONSISTENT, Usage.BOTH),
 
     /**
      * 1008;
@@ -99,7 +99,7 @@ public enum WebSocketCloseCode {
      * or if there is a need to hide specific details about the policy.
      * </i>
      */
-    VIOLATED(com.neovisionaries.ws.client.WebSocketCloseCode.VIOLATED),
+    VIOLATED(com.neovisionaries.ws.client.WebSocketCloseCode.VIOLATED, Usage.BOTH),
 
     /**
      * 1009;
@@ -109,7 +109,7 @@ public enum WebSocketCloseCode {
      * process.
      * </i>
      */
-    OVERSIZE(com.neovisionaries.ws.client.WebSocketCloseCode.OVERSIZE),
+    OVERSIZE(com.neovisionaries.ws.client.WebSocketCloseCode.OVERSIZE, Usage.BOTH),
 
     /**
      * 1010;
@@ -124,7 +124,7 @@ public enum WebSocketCloseCode {
      * WebSocket handshake instead.
      * </i>
      */
-    UNEXTENDED(com.neovisionaries.ws.client.WebSocketCloseCode.UNEXTENDED),
+    UNEXTENDED(com.neovisionaries.ws.client.WebSocketCloseCode.UNEXTENDED, Usage.BOTH),
 
     /**
      * 1011;
@@ -134,7 +134,7 @@ public enum WebSocketCloseCode {
      * fulfilling the request.
      * </i>
      */
-    UNEXPECTED(com.neovisionaries.ws.client.WebSocketCloseCode.UNEXPECTED),
+    UNEXPECTED(com.neovisionaries.ws.client.WebSocketCloseCode.UNEXPECTED, Usage.BOTH),
 
     /**
      * 1015;
@@ -146,77 +146,117 @@ public enum WebSocketCloseCode {
      * (e&#46;g&#46;, the server certificate can't be verified).
      * </i>
      */
-    INSECURE(com.neovisionaries.ws.client.WebSocketCloseCode.INSECURE),
+    INSECURE(com.neovisionaries.ws.client.WebSocketCloseCode.INSECURE, Usage.BOTH),
 
     /**
      * We're not sure what went wrong. Try reconnecting?
      */
-    UNKNOWN_ERROR(4000),
+    UNKNOWN_ERROR(4000, Usage.NORMAL),
 
     /**
      * You sent an invalid
      * <a href="https://discordapp.com/developers/docs/topics/gateway#payloads-and-opcodesspec.html">Gateway opcode</a>
      * or an invalid payload for an opcode. Don't do that!
      */
-    UNKNOWN_OPCODE(4001),
+    UNKNOWN_OPCODE(4001, Usage.BOTH),
 
     /**
      * You sent an invalid <a href="https://discordapp.com/developers/docs/topics/gateway#sending-payloads">payload</a>
      * to us. Don't do that!
      */
-    DECODE_ERROR(4002),
+    DECODE_ERROR(4002, Usage.NORMAL),
 
     /**
      * You sent us a payload prior to <a href="https://discordapp.com/developers/docs/topics/gateway#identify">
      * identifying</a>.
      */
-    NOT_AUTHENTICATED(4003),
+    NOT_AUTHENTICATED(4003, Usage.BOTH),
 
     /**
      * The account token sent with your <a href="https://discordapp.com/developers/docs/topics/gateway#identify">
      * identify payload</a> is incorrect.
      */
-    AUTHENTICATION_FAILED(4004),
+    AUTHENTICATION_FAILED(4004, Usage.BOTH),
 
     /**
      * You sent more than one identify payload. Don't do that!
      */
-    ALREADY_AUTHENTICATED(4005),
+    ALREADY_AUTHENTICATED(4005, Usage.NORMAL),
+
+    /**
+     * Your session is no longer valid.
+     */
+    SESSION_NO_LONGER_VALID(4006, Usage.VOICE),
 
     /**
      * The sequence sent when <a href="https://discordapp.com/developers/docs/topics/gateway#resume">resuming</a>
      * the session was invalid. Reconnect and start a new session.
      */
-    INVALID_SEQ(4007),
+    INVALID_SEQ(4007, Usage.NORMAL),
 
     /**
      * Woah nelly! You're sending payloads to us too quickly. Slow it down!
      */
-    RATE_LIMITED(4008),
+    RATE_LIMITED(4008, Usage.NORMAL),
 
     /**
      * Your session timed out. Reconnect and start a new one.
      */
-    SESSION_TIMEOUT(4009),
+    SESSION_TIMEOUT(4009, Usage.BOTH),
 
     /**
      * You sent us an invalid <a href="https://discordapp.com/developers/docs/topics/gateway#sharding">shard when
      * identifying</a>.
      */
-    INVALID_SHARD(4010),
+    INVALID_SHARD(4010, Usage.NORMAL),
 
     /**
      * The session would have handled too many guilds - you are required to
      * <a href="https://discordapp.com/developers/docs/topics/gateway#sharding">shard</a>
      * your connection in order to connect.
      */
-    SHARDING_REQUIRED(4011),
+    SHARDING_REQUIRED(4011, Usage.NORMAL),
+
+    /**
+     * The session would have handled too many guilds - you are required to
+     * <a href="https://discordapp.com/developers/docs/topics/gateway#sharding">shard</a>
+     * your connection in order to connect.
+     */
+    SERVER_NOT_FOUND(4011, Usage.VOICE),
+
+    /**
+     * The session would have handled too many guilds - you are required to
+     * <a href="https://discordapp.com/developers/docs/topics/gateway#sharding">shard</a>
+     * your connection in order to connect.
+     */
+    UNKNOWN_PROTOCOL(4012, Usage.VOICE),
+
+    /**
+     * The session would have handled too many guilds - you are required to
+     * <a href="https://discordapp.com/developers/docs/topics/gateway#sharding">shard</a>
+     * your connection in order to connect.
+     */
+    DISCONNECTED(4014, Usage.VOICE),
+
+    /**
+     * The session would have handled too many guilds - you are required to
+     * <a href="https://discordapp.com/developers/docs/topics/gateway#sharding">shard</a>
+     * your connection in order to connect.
+     */
+    VOICE_SERVER_CRASHED(4015, Usage.VOICE),
+
+    /**
+     * The session would have handled too many guilds - you are required to
+     * <a href="https://discordapp.com/developers/docs/topics/gateway#sharding">shard</a>
+     * your connection in order to connect.
+     */
+    UNKNOWN_ENCRYPTION_MODE(4016, Usage.VOICE),
 
     /**
      * Discord asked for a reconnect, and there is no pre-defined matching close reason,
      * thus 4999 is used which is unlikely to get assigned by Discord.
      */
-    COMMANDED_RECONNECT(4999);
+    COMMANDED_RECONNECT(4999, Usage.NORMAL);
 
     /**
      * A map for retrieving the enum instances by code.
@@ -224,13 +264,29 @@ public enum WebSocketCloseCode {
     private static final Map<Integer, WebSocketCloseCode> instanceByCode;
 
     /**
+     * A map for retrieving the voice enum instances by code.
+     */
+    private static final Map<Integer, WebSocketCloseCode> voiceInstanceByCode;
+
+    /**
      * The actual numeric close code
      */
     private final int code;
 
+    /**
+     * The actual numeric close code
+     */
+    private final Usage usage;
+
     static {
         instanceByCode = Collections.unmodifiableMap(
                 Arrays.stream(values())
+                        .filter(closeCode -> (closeCode.usage == Usage.BOTH) || (closeCode.usage == Usage.NORMAL))
+                        .collect(Collectors.toMap(WebSocketCloseCode::getCode, Function.identity())));
+
+        voiceInstanceByCode = Collections.unmodifiableMap(
+                Arrays.stream(values())
+                        .filter(closeCode -> (closeCode.usage == Usage.BOTH) || (closeCode.usage == Usage.VOICE))
                         .collect(Collectors.toMap(WebSocketCloseCode::getCode, Function.identity())));
     }
 
@@ -239,8 +295,9 @@ public enum WebSocketCloseCode {
      *
      * @param code The actual numeric close code.
      */
-    WebSocketCloseCode(int code) {
+    WebSocketCloseCode(int code, Usage usage) {
         this.code = code;
+        this.usage = usage;
     }
 
     /**
@@ -254,6 +311,16 @@ public enum WebSocketCloseCode {
     }
 
     /**
+     * Gets the voice web socket close code by actual numeric close code.
+     *
+     * @param code The actual numeric close code.
+     * @return The voice web socket close code with the actual numeric close code.
+     */
+    public static Optional<WebSocketCloseCode> fromCodeForVoice(int code) {
+        return Optional.ofNullable(voiceInstanceByCode.get(code));
+    }
+
+    /**
      * Gets the actual numeric close code.
      *
      * @return The actual numeric close code.
@@ -261,4 +328,12 @@ public enum WebSocketCloseCode {
     public int getCode() {
         return code;
     }
+
+    /**
+     * Defines what a close code is used for, normal web socket connections, voice web socket connections or both.
+     */
+    private enum Usage {
+        NORMAL, VOICE, BOTH
+    }
+
 }


### PR DESCRIPTION
- Add more Discord-defined constants as enums (gateway opcodes, voice gateway opcodes, voice web socket close codes)
- Use enum instead of magic numbers for opcodes