### PR TITLE
Improve Request Server Members Queue Consumer

### DIFF
--- a/src/main/java/de/btobastian/javacord/util/concurrent/ThreadPool.java
+++ b/src/main/java/de/btobastian/javacord/util/concurrent/ThreadPool.java
@@ -79,4 +79,17 @@ public class ThreadPool {
                                        new ThreadFactory("Javacord - " + threadName, false)));
     }
 
+    /**
+     * Gets an executor service which only uses a single daemon thread.
+     *
+     * @param threadName The thread name of the executor service.
+     *                   Will create a new one if the thread name is used the first time.
+     * @return The executor service with the given thread name. Never {@code null}!
+     */
+    public ExecutorService getSingleDaemonThreadExecutorService(String threadName) {
+        return executorServiceSingleThreads.computeIfAbsent(threadName, key ->
+                new ThreadPoolExecutor(0, 1, KEEP_ALIVE_TIME, TIME_UNIT, new LinkedBlockingQueue<>(),
+                                       new ThreadFactory("Javacord - " + threadName, true)));
+    }
+
 }


### PR DESCRIPTION
- Make it a daemon thread to not prevent orderly and timely VM shutdown
- Prevent any exception from killing the thread and instead log them except for interrupted exception
- Rename the thread from Guild to Server as it might be seen by the users
- Use ExecutorService#isShutdown() as abort condition for the thread to end the thread if the api gets disconnected but the VM not shutdown
- Check the abort condition once a minute
- Send requests for all currently waiting servers, not only for the first 50