### PR TITLE
Make Channel implementation-independent

### DIFF
--- a/src/main/java/de/btobastian/javacord/entity/channel/Channel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/Channel.java
@@ -1,13 +1,11 @@
 package de.btobastian.javacord.entity.channel;
 
-import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entity.DiscordEntity;
 import de.btobastian.javacord.entity.UpdatableFromCache;
 import de.btobastian.javacord.entity.permission.PermissionType;
 import de.btobastian.javacord.entity.user.User;
 import de.btobastian.javacord.listener.ChannelAttachableListener;
 import de.btobastian.javacord.listener.ObjectAttachableListener;
-import de.btobastian.javacord.util.ClassHelper;
 import de.btobastian.javacord.util.event.ListenerManager;
 
 import java.util.Collection;
@@ -16,7 +14,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 /**
  * The class represents a channel.
@@ -184,17 +181,8 @@ public interface Channel extends DiscordEntity, UpdatableFromCache {
      * @param <T> The type of the listener.
      * @return The managers for the added listener.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends ChannelAttachableListener & ObjectAttachableListener> Collection<ListenerManager<T>>
-    addChannelAttachableListener(T listener) {
-        return ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(ChannelAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .map(listenerClass -> ((ImplDiscordApi) getApi()).addObjectListener(Channel.class, getId(),
-                                                                                    listenerClass, listener))
-                .collect(Collectors.toList());
-    }
+    <T extends ChannelAttachableListener & ObjectAttachableListener> Collection<ListenerManager<T>>
+    addChannelAttachableListener(T listener);
 
     /**
      * Removes a listener that implements one or more {@code ChannelAttachableListener}s.
@@ -202,16 +190,7 @@ public interface Channel extends DiscordEntity, UpdatableFromCache {
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends ChannelAttachableListener & ObjectAttachableListener> void removeChannelAttachableListener(
-            T listener) {
-        ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(ChannelAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .forEach(listenerClass -> ((ImplDiscordApi) getApi()).removeObjectListener(Channel.class, getId(),
-                                                                                           listenerClass, listener));
-    }
+    <T extends ChannelAttachableListener & ObjectAttachableListener> void removeChannelAttachableListener(T listener);
 
     /**
      * Gets a map with all registered listeners that implement one or more {@code ChannelAttachableListener}s and
@@ -221,10 +200,8 @@ public interface Channel extends DiscordEntity, UpdatableFromCache {
      * @return A map with all registered listeners that implement one or more {@code ChannelAttachableListener}s
      * and their assigned listener classes they listen to.
      */
-    default <T extends ChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
-    getChannelAttachableListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(Channel.class, getId());
-    }
+    <T extends ChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getChannelAttachableListeners();
 
     /**
      * Removes a listener from this channel.
@@ -233,10 +210,8 @@ public interface Channel extends DiscordEntity, UpdatableFromCache {
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    default <T extends ChannelAttachableListener & ObjectAttachableListener> void removeListener(
-            Class<T> listenerClass, T listener) {
-        ((ImplDiscordApi) getApi()).removeObjectListener(Channel.class, getId(), listenerClass, listener);
-    }
+    <T extends ChannelAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener);
 
     @Override
     default Optional<? extends Channel> getCurrentCachedInstance() {

--- a/src/main/java/de/btobastian/javacord/entity/channel/GroupChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/GroupChannel.java
@@ -1,16 +1,11 @@
 package de.btobastian.javacord.entity.channel;
 
-import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entity.Icon;
 import de.btobastian.javacord.entity.user.User;
-import de.btobastian.javacord.listener.ChannelAttachableListener;
 import de.btobastian.javacord.listener.ObjectAttachableListener;
-import de.btobastian.javacord.listener.TextChannelAttachableListener;
-import de.btobastian.javacord.listener.VoiceChannelAttachableListener;
 import de.btobastian.javacord.listener.channel.group.GroupChannelAttachableListener;
 import de.btobastian.javacord.listener.channel.group.GroupChannelChangeNameListener;
 import de.btobastian.javacord.listener.channel.group.GroupChannelDeleteListener;
-import de.btobastian.javacord.util.ClassHelper;
 import de.btobastian.javacord.util.event.ListenerManager;
 
 import java.util.Collection;
@@ -19,8 +14,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This class represents a group channel. Group channels are not supported by bot accounts!
@@ -89,21 +82,15 @@ public interface GroupChannel extends TextChannel, VoiceChannel {
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<GroupChannelChangeNameListener> addGroupChannelChangeNameListener(
-            GroupChannelChangeNameListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                GroupChannel.class, getId(), GroupChannelChangeNameListener.class, listener);
-    }
+    ListenerManager<GroupChannelChangeNameListener> addGroupChannelChangeNameListener(
+            GroupChannelChangeNameListener listener);
 
     /**
      * Gets a list with all registered group channel change name listeners.
      *
      * @return A list with all registered group channel change name listeners.
      */
-    default List<GroupChannelChangeNameListener> getGroupChannelChangeNameListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(
-                GroupChannel.class, getId(), GroupChannelChangeNameListener.class);
-    }
+    List<GroupChannelChangeNameListener> getGroupChannelChangeNameListeners();
 
     /**
      * Adds a listener, which listens to this channel being deleted.
@@ -111,21 +98,14 @@ public interface GroupChannel extends TextChannel, VoiceChannel {
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<GroupChannelDeleteListener> addGroupChannelDeleteListener(
-            GroupChannelDeleteListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                GroupChannel.class, getId(), GroupChannelDeleteListener.class, listener);
-    }
+    ListenerManager<GroupChannelDeleteListener> addGroupChannelDeleteListener(GroupChannelDeleteListener listener);
 
     /**
      * Gets a list with all registered group channel delete listeners.
      *
      * @return A list with all registered group channel delete listeners.
      */
-    default List<GroupChannelDeleteListener> getGroupChannelDeleteListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(
-                GroupChannel.class, getId(), GroupChannelDeleteListener.class);
-    }
+    List<GroupChannelDeleteListener> getGroupChannelDeleteListeners();
 
     /**
      * Adds a listener that implements one or more {@code GroupChannelAttachableListener}s.
@@ -137,31 +117,8 @@ public interface GroupChannel extends TextChannel, VoiceChannel {
      * @param <T> The type of the listener.
      * @return The managers for the added listener.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends GroupChannelAttachableListener & ObjectAttachableListener>
-    Collection<ListenerManager<? extends GroupChannelAttachableListener>> addGroupChannelAttachableListener(
-            T listener) {
-        return ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(GroupChannelAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .flatMap(listenerClass -> {
-                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        return addChannelAttachableListener(
-                                (ChannelAttachableListener & ObjectAttachableListener) listener).stream();
-                    } else if (TextChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        return addTextChannelAttachableListener(
-                                (TextChannelAttachableListener & ObjectAttachableListener) listener).stream();
-                    } else if (VoiceChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        return addVoiceChannelAttachableListener(
-                                (VoiceChannelAttachableListener & ObjectAttachableListener) listener).stream();
-                    } else {
-                        return Stream.of(((ImplDiscordApi) getApi()).addObjectListener(GroupChannel.class, getId(),
-                                                                                       listenerClass, listener));
-                    }
-                })
-                .collect(Collectors.toList());
-    }
+    <T extends GroupChannelAttachableListener & ObjectAttachableListener>
+    Collection<ListenerManager<? extends GroupChannelAttachableListener>> addGroupChannelAttachableListener(T listener);
 
     /**
      * Removes a listener that implements one or more {@code GroupChannelAttachableListener}s.
@@ -169,29 +126,8 @@ public interface GroupChannel extends TextChannel, VoiceChannel {
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends GroupChannelAttachableListener & ObjectAttachableListener> void
-    removeGroupChannelAttachableListener(T listener) {
-        ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(GroupChannelAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .forEach(listenerClass -> {
-                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        removeChannelAttachableListener(
-                                (ChannelAttachableListener & ObjectAttachableListener) listener);
-                    } else if (TextChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        removeTextChannelAttachableListener(
-                                (TextChannelAttachableListener & ObjectAttachableListener) listener);
-                    } else if (VoiceChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        removeVoiceChannelAttachableListener(
-                                (VoiceChannelAttachableListener & ObjectAttachableListener) listener);
-                    } else {
-                        ((ImplDiscordApi) getApi()).removeObjectListener(GroupChannel.class, getId(),
-                                                                         listenerClass, listener);
-                    }
-                });
-    }
+    <T extends GroupChannelAttachableListener & ObjectAttachableListener> void removeGroupChannelAttachableListener(
+            T listener);
 
     /**
      * Gets a map with all registered listeners that implement one or more {@code GroupChannelAttachableListener}s and
@@ -201,34 +137,8 @@ public interface GroupChannel extends TextChannel, VoiceChannel {
      * @return A map with all registered listeners that implement one or more {@code GroupChannelAttachableListener}s
      * and their assigned listener classes they listen to.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends GroupChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
-    getGroupChannelAttachableListeners() {
-        Map<T, List<Class<T>>> groupChannelListeners =
-                ((ImplDiscordApi) getApi()).getObjectListeners(GroupChannel.class, getId());
-        getTextChannelAttachableListeners().forEach((listener, listenerClasses) -> groupChannelListeners
-                .merge((T) listener,
-                       (List<Class<T>>) (Object) listenerClasses,
-                       (listenerClasses1, listenerClasses2) -> {
-                           listenerClasses1.addAll(listenerClasses2);
-                           return listenerClasses1;
-                       }));
-        getVoiceChannelAttachableListeners().forEach((listener, listenerClasses) -> groupChannelListeners
-                .merge((T) listener,
-                       (List<Class<T>>) (Object) listenerClasses,
-                       (listenerClasses1, listenerClasses2) -> {
-                           listenerClasses1.addAll(listenerClasses2);
-                           return listenerClasses1;
-                       }));
-        getChannelAttachableListeners().forEach((listener, listenerClasses) -> groupChannelListeners
-                .merge((T) listener,
-                       (List<Class<T>>) (Object) listenerClasses,
-                       (listenerClasses1, listenerClasses2) -> {
-                           listenerClasses1.addAll(listenerClasses2);
-                           return listenerClasses1;
-                       }));
-        return groupChannelListeners;
-    }
+    <T extends GroupChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getGroupChannelAttachableListeners();
 
     /**
      * Removes a listener from this group channel.
@@ -237,10 +147,8 @@ public interface GroupChannel extends TextChannel, VoiceChannel {
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    default <T extends GroupChannelAttachableListener & ObjectAttachableListener> void removeListener(
-            Class<T> listenerClass, T listener) {
-        ((ImplDiscordApi) getApi()).removeObjectListener(GroupChannel.class, getId(), listenerClass, listener);
-    }
+    <T extends GroupChannelAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener);
 
     @Override
     default Optional<GroupChannel> getCurrentCachedInstance() {

--- a/src/main/java/de/btobastian/javacord/entity/channel/InternalChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/InternalChannel.java
@@ -1,0 +1,52 @@
+package de.btobastian.javacord.entity.channel;
+
+import de.btobastian.javacord.ImplDiscordApi;
+import de.btobastian.javacord.listener.ChannelAttachableListener;
+import de.btobastian.javacord.listener.ObjectAttachableListener;
+import de.btobastian.javacord.util.ClassHelper;
+import de.btobastian.javacord.util.event.ListenerManager;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public interface InternalChannel extends Channel {
+    @Override
+    @SuppressWarnings("unchecked")
+    default <T extends ChannelAttachableListener & ObjectAttachableListener> Collection<ListenerManager<T>>
+    addChannelAttachableListener(T listener) {
+        return ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(ChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .map(listenerClass -> ((ImplDiscordApi) getApi()).addObjectListener(Channel.class, getId(),
+                                                                                    listenerClass, listener))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    default <T extends ChannelAttachableListener & ObjectAttachableListener> void removeChannelAttachableListener(
+            T listener) {
+        ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(ChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .forEach(listenerClass -> ((ImplDiscordApi) getApi()).removeObjectListener(Channel.class, getId(),
+                                                                                           listenerClass, listener));
+    }
+
+    @Override
+    default <T extends ChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getChannelAttachableListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Channel.class, getId());
+    }
+
+    @Override
+    default <T extends ChannelAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(Channel.class, getId(), listenerClass, listener);
+    }
+
+}

--- a/src/main/java/de/btobastian/javacord/entity/channel/InternalServerChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/InternalServerChannel.java
@@ -1,0 +1,221 @@
+package de.btobastian.javacord.entity.channel;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import de.btobastian.javacord.ImplDiscordApi;
+import de.btobastian.javacord.entity.permission.PermissionState;
+import de.btobastian.javacord.entity.permission.PermissionType;
+import de.btobastian.javacord.entity.permission.Permissions;
+import de.btobastian.javacord.entity.permission.PermissionsBuilder;
+import de.btobastian.javacord.entity.permission.Role;
+import de.btobastian.javacord.entity.permission.impl.ImplPermissions;
+import de.btobastian.javacord.entity.server.Server;
+import de.btobastian.javacord.entity.server.invite.RichInvite;
+import de.btobastian.javacord.entity.server.invite.impl.ImplInvite;
+import de.btobastian.javacord.entity.user.User;
+import de.btobastian.javacord.listener.ChannelAttachableListener;
+import de.btobastian.javacord.listener.ObjectAttachableListener;
+import de.btobastian.javacord.listener.channel.server.ServerChannelAttachableListener;
+import de.btobastian.javacord.listener.channel.server.ServerChannelChangeNameListener;
+import de.btobastian.javacord.listener.channel.server.ServerChannelChangeOverwrittenPermissionsListener;
+import de.btobastian.javacord.listener.channel.server.ServerChannelChangePositionListener;
+import de.btobastian.javacord.listener.channel.server.ServerChannelDeleteListener;
+import de.btobastian.javacord.util.ClassHelper;
+import de.btobastian.javacord.util.event.ListenerManager;
+import de.btobastian.javacord.util.rest.RestEndpoint;
+import de.btobastian.javacord.util.rest.RestMethod;
+import de.btobastian.javacord.util.rest.RestRequest;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public interface InternalServerChannel extends ServerChannel {
+
+    @Override
+    default CompletableFuture<Collection<RichInvite>> getInvites() {
+        return new RestRequest<Collection<RichInvite>>(getApi(), RestMethod.GET, RestEndpoint.CHANNEL_INVITE)
+                .setUrlParameters(getIdAsString())
+                .execute(result -> {
+                    Collection<RichInvite> invites = new HashSet<>();
+                    for (JsonNode inviteJson : result.getJsonBody()) {
+                        invites.add(new ImplInvite(getApi(), inviteJson));
+                    }
+                    return Collections.unmodifiableCollection(invites);
+                });
+    }
+
+    @Override
+    default Permissions getEffectiveOverwrittenPermissions(User user) {
+        PermissionsBuilder builder = new PermissionsBuilder(ImplPermissions.EMPTY_PERMISSIONS);
+        Server server = getServer();
+        Role everyoneRole = server.getEveryoneRole();
+        Permissions everyoneRolePermissionOverwrites = getOverwrittenPermissions(everyoneRole);
+        for (PermissionType type : PermissionType.values()) {
+            if (everyoneRolePermissionOverwrites.getState(type) == PermissionState.DENIED) {
+                builder.setState(type, PermissionState.DENIED);
+            }
+            if (everyoneRolePermissionOverwrites.getState(type) == PermissionState.ALLOWED) {
+                builder.setState(type, PermissionState.ALLOWED);
+            }
+        }
+        List<Role> rolesOfUser = new ArrayList<>(server.getRolesOf(user));
+        rolesOfUser.remove(everyoneRole);
+        List<Permissions> permissionOverwrites = rolesOfUser.stream()
+                .map(this::getOverwrittenPermissions)
+                .collect(Collectors.toList());
+        for (Permissions permissions : permissionOverwrites) {
+            for (PermissionType type : PermissionType.values()) {
+                if (permissions.getState(type) == PermissionState.DENIED) {
+                    builder.setState(type, PermissionState.DENIED);
+                }
+            }
+        }
+        for (Permissions permissions : permissionOverwrites) {
+            for (PermissionType type : PermissionType.values()) {
+                if (permissions.getState(type) == PermissionState.ALLOWED) {
+                    builder.setState(type, PermissionState.ALLOWED);
+                }
+            }
+        }
+        for (PermissionType type : PermissionType.values()) {
+            Permissions permissions = getOverwrittenPermissions(user);
+            if (permissions.getState(type) == PermissionState.DENIED) {
+                builder.setState(type, PermissionState.DENIED);
+            }
+            if (permissions.getState(type) == PermissionState.ALLOWED) {
+                builder.setState(type, PermissionState.ALLOWED);
+            }
+        }
+        return builder.build();
+    }
+
+    @Override
+    default CompletableFuture<Void> delete(String reason) {
+        return new RestRequest<Void>(getApi(), RestMethod.DELETE, RestEndpoint.CHANNEL)
+                .setUrlParameters(getIdAsString())
+                .setAuditLogReason(reason)
+                .execute(result -> null);
+    }
+
+    @Override
+    default ListenerManager<ServerChannelDeleteListener> addServerChannelDeleteListener(
+            ServerChannelDeleteListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                ServerChannel.class, getId(), ServerChannelDeleteListener.class, listener);
+    }
+
+    @Override
+    default List<ServerChannelDeleteListener> getServerChannelDeleteListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                ServerChannel.class, getId(), ServerChannelDeleteListener.class);
+    }
+
+    @Override
+    default ListenerManager<ServerChannelChangeNameListener> addServerChannelChangeNameListener(
+            ServerChannelChangeNameListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                ServerChannel.class, getId(), ServerChannelChangeNameListener.class, listener);
+    }
+
+    @Override
+    default List<ServerChannelChangeNameListener> getServerChannelChangeNameListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                ServerChannel.class, getId(), ServerChannelChangeNameListener.class);
+    }
+
+    @Override
+    default ListenerManager<ServerChannelChangePositionListener> addServerChannelChangePositionListener(
+            ServerChannelChangePositionListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                ServerChannel.class, getId(), ServerChannelChangePositionListener.class, listener);
+    }
+
+    @Override
+    default List<ServerChannelChangePositionListener> getServerChannelChangePositionListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                ServerChannel.class, getId(), ServerChannelChangePositionListener.class);
+    }
+
+    @Override
+    default ListenerManager<ServerChannelChangeOverwrittenPermissionsListener>
+    addServerChannelChangeOverwrittenPermissionsListener(ServerChannelChangeOverwrittenPermissionsListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                ServerChannel.class, getId(), ServerChannelChangeOverwrittenPermissionsListener.class, listener);
+    }
+
+    @Override
+    default List<ServerChannelChangeOverwrittenPermissionsListener>
+    getServerChannelChangeOverwrittenPermissionsListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                ServerChannel.class, getId(), ServerChannelChangeOverwrittenPermissionsListener.class);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    default <T extends ServerChannelAttachableListener & ObjectAttachableListener>
+    Collection<ListenerManager<? extends ServerChannelAttachableListener>>
+    addServerChannelAttachableListener(T listener) {
+        return ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(ServerChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .flatMap(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else {
+                        return Stream.of(((ImplDiscordApi) getApi()).addObjectListener(ServerChannel.class, getId(),
+                                                                                       listenerClass, listener));
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    default <T extends ServerChannelAttachableListener & ObjectAttachableListener> void
+    removeServerChannelAttachableListener(T listener) {
+        ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(ServerChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .forEach(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else {
+                        ((ImplDiscordApi) getApi()).removeObjectListener(ServerChannel.class, getId(),
+                                                                         listenerClass, listener);
+                    }
+                });
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    default <T extends ServerChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getServerChannelAttachableListeners() {
+        Map<T, List<Class<T>>> serverChannelListeners =
+                ((ImplDiscordApi) getApi()).getObjectListeners(ServerChannel.class, getId());
+        getChannelAttachableListeners().forEach((listener, listenerClasses) -> serverChannelListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        return serverChannelListeners;
+    }
+
+    @Override
+    default <T extends ServerChannelAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(ServerChannel.class, getId(), listenerClass, listener);
+    }
+
+}

--- a/src/main/java/de/btobastian/javacord/entity/channel/InternalTextChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/InternalTextChannel.java
@@ -1,0 +1,383 @@
+package de.btobastian.javacord.entity.channel;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import de.btobastian.javacord.ImplDiscordApi;
+import de.btobastian.javacord.entity.message.Message;
+import de.btobastian.javacord.entity.message.MessageSet;
+import de.btobastian.javacord.entity.message.impl.ImplMessageSet;
+import de.btobastian.javacord.entity.webhook.Webhook;
+import de.btobastian.javacord.entity.webhook.impl.ImplWebhook;
+import de.btobastian.javacord.listener.ChannelAttachableListener;
+import de.btobastian.javacord.listener.ObjectAttachableListener;
+import de.btobastian.javacord.listener.TextChannelAttachableListener;
+import de.btobastian.javacord.listener.message.CachedMessagePinListener;
+import de.btobastian.javacord.listener.message.CachedMessageUnpinListener;
+import de.btobastian.javacord.listener.message.ChannelPinsUpdateListener;
+import de.btobastian.javacord.listener.message.MessageCreateListener;
+import de.btobastian.javacord.listener.message.MessageDeleteListener;
+import de.btobastian.javacord.listener.message.MessageEditListener;
+import de.btobastian.javacord.listener.message.reaction.ReactionAddListener;
+import de.btobastian.javacord.listener.message.reaction.ReactionRemoveAllListener;
+import de.btobastian.javacord.listener.message.reaction.ReactionRemoveListener;
+import de.btobastian.javacord.listener.user.UserStartTypingListener;
+import de.btobastian.javacord.util.ClassHelper;
+import de.btobastian.javacord.util.event.ListenerManager;
+import de.btobastian.javacord.util.rest.RestEndpoint;
+import de.btobastian.javacord.util.rest.RestMethod;
+import de.btobastian.javacord.util.rest.RestRequest;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public interface InternalTextChannel extends TextChannel {
+
+    @Override
+    default CompletableFuture<Void> type() {
+        return new RestRequest<Void>(getApi(), RestMethod.POST, RestEndpoint.CHANNEL_TYPING)
+                .setRatelimitRetries(0)
+                .setUrlParameters(getIdAsString())
+                .execute(result -> null);
+    }
+
+    @Override
+    default CompletableFuture<Void> bulkDelete(long... messageIds) {
+        ObjectNode body = JsonNodeFactory.instance.objectNode();
+        ArrayNode messages = body.putArray("messages");
+        LongStream.of(messageIds).boxed()
+                .map(Long::toUnsignedString)
+                .forEach(messages::add);
+
+        return new RestRequest<Void>(getApi(), RestMethod.POST, RestEndpoint.MESSAGES_BULK_DELETE)
+                .setRatelimitRetries(0)
+                .setUrlParameters(getIdAsString())
+                .setBody(body)
+                .execute(result -> null);
+    }
+
+    @Override
+    default CompletableFuture<Message> getMessageById(long id) {
+        return getApi().getCachedMessageById(id)
+                .map(CompletableFuture::completedFuture)
+                .orElseGet(() -> new RestRequest<Message>(getApi(), RestMethod.GET, RestEndpoint.MESSAGE)
+                .setUrlParameters(getIdAsString(), Long.toUnsignedString(id))
+                .execute(result -> ((ImplDiscordApi) getApi()).getOrCreateMessage(this, result.getJsonBody())));
+    }
+
+    @Override
+    default CompletableFuture<MessageSet> getPins() {
+        return new RestRequest<MessageSet>(getApi(), RestMethod.GET, RestEndpoint.PINS)
+                .setUrlParameters(getIdAsString())
+                .execute(result -> {
+                    Collection<Message> pins = StreamSupport.stream(result.getJsonBody().spliterator(), false)
+                            .map(pinJson -> ((ImplDiscordApi) getApi()).getOrCreateMessage(this, pinJson))
+                            .collect(Collectors.toList());
+                    return new ImplMessageSet(pins);
+                });
+    }
+
+    @Override
+    default CompletableFuture<MessageSet> getMessages(int limit) {
+        return ImplMessageSet.getMessages(this, limit);
+    }
+
+    @Override
+    default CompletableFuture<MessageSet> getMessagesUntil(Predicate<Message> condition) {
+        return ImplMessageSet.getMessagesUntil(this, condition);
+    }
+
+    @Override
+    default CompletableFuture<MessageSet> getMessagesWhile(Predicate<Message> condition) {
+        return ImplMessageSet.getMessagesWhile(this, condition);
+    }
+
+    @Override
+    default Stream<Message> getMessagesAsStream() {
+        return ImplMessageSet.getMessagesAsStream(this);
+    }
+
+    @Override
+    default CompletableFuture<MessageSet> getMessagesBefore(int limit, long before) {
+        return ImplMessageSet.getMessagesBefore(this, limit, before);
+    }
+
+    @Override
+    default CompletableFuture<MessageSet> getMessagesBeforeUntil(Predicate<Message> condition, long before) {
+        return ImplMessageSet.getMessagesBeforeUntil(this, condition, before);
+    }
+
+    @Override
+    default CompletableFuture<MessageSet> getMessagesBeforeWhile(Predicate<Message> condition, long before) {
+        return ImplMessageSet.getMessagesBeforeWhile(this, condition, before);
+    }
+
+    @Override
+    default Stream<Message> getMessagesBeforeAsStream(long before) {
+        return ImplMessageSet.getMessagesBeforeAsStream(this, before);
+    }
+
+    @Override
+    default CompletableFuture<MessageSet> getMessagesAfter(int limit, long after) {
+        return ImplMessageSet.getMessagesAfter(this, limit, after);
+    }
+
+    @Override
+    default CompletableFuture<MessageSet> getMessagesAfterUntil(Predicate<Message> condition, long after) {
+        return ImplMessageSet.getMessagesAfterUntil(this, condition, after);
+    }
+
+    @Override
+    default CompletableFuture<MessageSet> getMessagesAfterWhile(Predicate<Message> condition, long after) {
+        return ImplMessageSet.getMessagesAfterWhile(this, condition, after);
+    }
+
+    @Override
+    default Stream<Message> getMessagesAfterAsStream(long after) {
+        return ImplMessageSet.getMessagesAfterAsStream(this, after);
+    }
+
+    @Override
+    default CompletableFuture<MessageSet> getMessagesAround(int limit, long around) {
+        return ImplMessageSet.getMessagesAround(this, limit, around);
+    }
+
+    @Override
+    default CompletableFuture<MessageSet> getMessagesAroundUntil(Predicate<Message> condition, long around) {
+        return ImplMessageSet.getMessagesAroundUntil(this, condition, around);
+    }
+
+    @Override
+    default CompletableFuture<MessageSet> getMessagesAroundWhile(Predicate<Message> condition, long around) {
+        return ImplMessageSet.getMessagesAroundWhile(this, condition, around);
+    }
+
+    @Override
+    default Stream<Message> getMessagesAroundAsStream(long around) {
+        return ImplMessageSet.getMessagesAroundAsStream(this, around);
+    }
+
+    @Override
+    default CompletableFuture<MessageSet> getMessagesBetween(long from, long to) {
+        return ImplMessageSet.getMessagesBetween(this, from, to);
+    }
+
+    @Override
+    default CompletableFuture<MessageSet> getMessagesBetweenUntil(Predicate<Message> condition, long from, long to) {
+        return ImplMessageSet.getMessagesBetweenUntil(this, condition, from, to);
+    }
+
+    @Override
+    default CompletableFuture<MessageSet> getMessagesBetweenWhile(Predicate<Message> condition, long from, long to) {
+        return ImplMessageSet.getMessagesBetweenWhile(this, condition, from, to);
+    }
+
+    @Override
+    default Stream<Message> getMessagesBetweenAsStream(long from, long to) {
+        return ImplMessageSet.getMessagesBetweenAsStream(this, from, to);
+    }
+
+    @Override
+    default CompletableFuture<List<Webhook>> getWebhooks() {
+        return new RestRequest<List<Webhook>>(getApi(), RestMethod.GET, RestEndpoint.CHANNEL_WEBHOOK)
+                .setUrlParameters(getIdAsString())
+                .execute(result -> {
+                    List<Webhook> webhooks = new ArrayList<>();
+                    for (JsonNode webhook : result.getJsonBody()) {
+                        webhooks.add(new ImplWebhook(getApi(), webhook));
+                    }
+                    return Collections.unmodifiableList(webhooks);
+                });
+    }
+
+    @Override
+    default ListenerManager<MessageCreateListener> addMessageCreateListener(MessageCreateListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                TextChannel.class, getId(), MessageCreateListener.class, listener);
+    }
+
+    @Override
+    default List<MessageCreateListener> getMessageCreateListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(TextChannel.class, getId(), MessageCreateListener.class);
+    }
+
+    @Override
+    default ListenerManager<UserStartTypingListener> addUserStartTypingListener(UserStartTypingListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                TextChannel.class, getId(), UserStartTypingListener.class, listener);
+    }
+
+    @Override
+    default List<UserStartTypingListener> getUserStartTypingListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                TextChannel.class, getId(), UserStartTypingListener.class);
+    }
+
+    @Override
+    default ListenerManager<MessageDeleteListener> addMessageDeleteListener(MessageDeleteListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                TextChannel.class, getId(), MessageDeleteListener.class, listener);
+    }
+
+    @Override
+    default List<MessageDeleteListener> getMessageDeleteListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(TextChannel.class, getId(), MessageDeleteListener.class);
+    }
+
+    @Override
+    default ListenerManager<MessageEditListener> addMessageEditListener(MessageEditListener listener) {
+        return ((ImplDiscordApi) getApi())
+                .addObjectListener(TextChannel.class, getId(), MessageEditListener.class, listener);
+    }
+
+    @Override
+    default List<MessageEditListener> getMessageEditListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(TextChannel.class, getId(), MessageEditListener.class);
+    }
+
+    @Override
+    default ListenerManager<ReactionAddListener> addReactionAddListener(ReactionAddListener listener) {
+        return ((ImplDiscordApi) getApi())
+                .addObjectListener(TextChannel.class, getId(), ReactionAddListener.class, listener);
+    }
+
+    @Override
+    default List<ReactionAddListener> getReactionAddListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(TextChannel.class, getId(), ReactionAddListener.class);
+    }
+
+    @Override
+    default ListenerManager<ReactionRemoveListener> addReactionRemoveListener(ReactionRemoveListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                TextChannel.class, getId(), ReactionRemoveListener.class, listener);
+    }
+
+    @Override
+    default List<ReactionRemoveListener> getReactionRemoveListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(TextChannel.class, getId(), ReactionRemoveListener.class);
+    }
+
+    @Override
+    default ListenerManager<ReactionRemoveAllListener> addReactionRemoveAllListener(
+            ReactionRemoveAllListener listener) {
+        return ((ImplDiscordApi) getApi())
+                .addObjectListener(TextChannel.class, getId(), ReactionRemoveAllListener.class, listener);
+    }
+
+    @Override
+    default List<ReactionRemoveAllListener> getReactionRemoveAllListeners() {
+        return ((ImplDiscordApi) getApi())
+                .getObjectListeners(TextChannel.class, getId(), ReactionRemoveAllListener.class);
+    }
+
+    @Override
+    default ListenerManager<ChannelPinsUpdateListener> addChannelPinsUpdateListener(
+            ChannelPinsUpdateListener listener) {
+        return ((ImplDiscordApi) getApi())
+                .addObjectListener(TextChannel.class, getId(), ChannelPinsUpdateListener.class, listener);
+    }
+
+    @Override
+    default List<ChannelPinsUpdateListener> getChannelPinsUpdateListeners() {
+        return ((ImplDiscordApi) getApi())
+                .getObjectListeners(TextChannel.class, getId(), ChannelPinsUpdateListener.class);
+    }
+
+    @Override
+    default ListenerManager<CachedMessagePinListener> addCachedMessagePinListener(CachedMessagePinListener listener) {
+        return ((ImplDiscordApi) getApi())
+                .addObjectListener(TextChannel.class, getId(), CachedMessagePinListener.class, listener);
+    }
+
+    @Override
+    default List<CachedMessagePinListener> getCachedMessagePinListeners() {
+        return ((ImplDiscordApi) getApi())
+                .getObjectListeners(TextChannel.class, getId(), CachedMessagePinListener.class);
+    }
+
+    @Override
+    default ListenerManager<CachedMessageUnpinListener> addCachedMessageUnpinListener(
+            CachedMessageUnpinListener listener) {
+        return ((ImplDiscordApi) getApi())
+                .addObjectListener(TextChannel.class, getId(), CachedMessageUnpinListener.class, listener);
+    }
+
+    @Override
+    default List<CachedMessageUnpinListener> getCachedMessageUnpinListeners() {
+        return ((ImplDiscordApi) getApi())
+                .getObjectListeners(TextChannel.class, getId(), CachedMessageUnpinListener.class);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    default <T extends TextChannelAttachableListener & ObjectAttachableListener>
+    Collection<ListenerManager<? extends TextChannelAttachableListener>>
+    addTextChannelAttachableListener(T listener) {
+        return ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(TextChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .flatMap(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else {
+                        return Stream.of(((ImplDiscordApi) getApi()).addObjectListener(TextChannel.class, getId(),
+                                                                                       listenerClass, listener));
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    default <T extends TextChannelAttachableListener & ObjectAttachableListener> void
+    removeTextChannelAttachableListener(T listener) {
+        ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(TextChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .forEach(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else {
+                        ((ImplDiscordApi) getApi()).removeObjectListener(TextChannel.class, getId(),
+                                                                         listenerClass, listener);
+                    }
+                });
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    default <T extends TextChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getTextChannelAttachableListeners() {
+        Map<T, List<Class<T>>> textChannelListeners =
+                ((ImplDiscordApi) getApi()).getObjectListeners(TextChannel.class, getId());
+        getChannelAttachableListeners().forEach((listener, listenerClasses) -> textChannelListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        return textChannelListeners;
+    }
+
+    @Override
+    default <T extends TextChannelAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(TextChannel.class, getId(), listenerClass, listener);
+    }
+
+}

--- a/src/main/java/de/btobastian/javacord/entity/channel/InternalVoiceChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/InternalVoiceChannel.java
@@ -1,0 +1,80 @@
+package de.btobastian.javacord.entity.channel;
+
+import de.btobastian.javacord.ImplDiscordApi;
+import de.btobastian.javacord.listener.ChannelAttachableListener;
+import de.btobastian.javacord.listener.ObjectAttachableListener;
+import de.btobastian.javacord.listener.VoiceChannelAttachableListener;
+import de.btobastian.javacord.util.ClassHelper;
+import de.btobastian.javacord.util.event.ListenerManager;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public interface InternalVoiceChannel extends VoiceChannel {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    default <T extends VoiceChannelAttachableListener & ObjectAttachableListener>
+    Collection<ListenerManager<? extends VoiceChannelAttachableListener>>
+    addVoiceChannelAttachableListener(T listener) {
+        return ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(VoiceChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .flatMap(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else {
+                        return Stream.of(((ImplDiscordApi) getApi()).addObjectListener(VoiceChannel.class, getId(),
+                                                                                       listenerClass, listener));
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    default <T extends VoiceChannelAttachableListener & ObjectAttachableListener> void
+    removeVoiceChannelAttachableListener(T listener) {
+        ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(VoiceChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .forEach(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else {
+                        ((ImplDiscordApi) getApi()).removeObjectListener(VoiceChannel.class, getId(),
+                                                                         listenerClass, listener);
+                    }
+                });
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    default <T extends VoiceChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getVoiceChannelAttachableListeners() {
+        Map<T, List<Class<T>>> voiceChannelListeners =
+                ((ImplDiscordApi) getApi()).getObjectListeners(VoiceChannel.class, getId());
+        getChannelAttachableListeners().forEach((listener, listenerClasses) -> voiceChannelListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        return voiceChannelListeners;
+    }
+
+    @Override
+    default <T extends VoiceChannelAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(VoiceChannel.class, getId(), listenerClass, listener);
+    }
+
+}

--- a/src/main/java/de/btobastian/javacord/entity/channel/PrivateChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/PrivateChannel.java
@@ -1,14 +1,9 @@
 package de.btobastian.javacord.entity.channel;
 
-import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entity.user.User;
-import de.btobastian.javacord.listener.ChannelAttachableListener;
 import de.btobastian.javacord.listener.ObjectAttachableListener;
-import de.btobastian.javacord.listener.TextChannelAttachableListener;
-import de.btobastian.javacord.listener.VoiceChannelAttachableListener;
 import de.btobastian.javacord.listener.user.channel.PrivateChannelAttachableListener;
 import de.btobastian.javacord.listener.user.channel.PrivateChannelDeleteListener;
-import de.btobastian.javacord.util.ClassHelper;
 import de.btobastian.javacord.util.event.ListenerManager;
 
 import java.util.Collection;
@@ -17,8 +12,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This class represents a private channel.
@@ -45,21 +38,15 @@ public interface PrivateChannel extends TextChannel, VoiceChannel {
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<PrivateChannelDeleteListener> addPrivateChannelDeleteListener(
-            PrivateChannelDeleteListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                PrivateChannel.class, getId(), PrivateChannelDeleteListener.class, listener);
-    }
+    ListenerManager<PrivateChannelDeleteListener> addPrivateChannelDeleteListener(
+            PrivateChannelDeleteListener listener);
 
     /**
      * Gets a list with all registered private channel delete listeners.
      *
      * @return A list with all registered private channel delete listeners.
      */
-    default List<PrivateChannelDeleteListener> getPrivateChannelDeleteListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(
-                PrivateChannel.class, getId(), PrivateChannelDeleteListener.class);
-    }
+    List<PrivateChannelDeleteListener> getPrivateChannelDeleteListeners();
 
     /**
      * Adds a listener that implements one or more {@code PrivateChannelAttachableListener}s.
@@ -71,31 +58,9 @@ public interface PrivateChannel extends TextChannel, VoiceChannel {
      * @param <T> The type of the listener.
      * @return The managers for the added listener.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends PrivateChannelAttachableListener & ObjectAttachableListener>
+    <T extends PrivateChannelAttachableListener & ObjectAttachableListener>
     Collection<ListenerManager<? extends PrivateChannelAttachableListener>> addPrivateChannelAttachableListener(
-            T listener) {
-        return ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(PrivateChannelAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .flatMap(listenerClass -> {
-                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        return addChannelAttachableListener(
-                                (ChannelAttachableListener & ObjectAttachableListener) listener).stream();
-                    } else if (TextChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        return addTextChannelAttachableListener(
-                                (TextChannelAttachableListener & ObjectAttachableListener) listener).stream();
-                    } else if (VoiceChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        return addVoiceChannelAttachableListener(
-                                (VoiceChannelAttachableListener & ObjectAttachableListener) listener).stream();
-                    } else {
-                        return Stream.of(((ImplDiscordApi) getApi()).addObjectListener(PrivateChannel.class, getId(),
-                                                                                       listenerClass, listener));
-                    }
-                })
-                .collect(Collectors.toList());
-    }
+            T listener);
 
     /**
      * Removes a listener that implements one or more {@code PrivateChannelAttachableListener}s.
@@ -103,29 +68,8 @@ public interface PrivateChannel extends TextChannel, VoiceChannel {
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends PrivateChannelAttachableListener & ObjectAttachableListener> void
-    removePrivateChannelAttachableListener(T listener) {
-        ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(PrivateChannelAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .forEach(listenerClass -> {
-                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        removeChannelAttachableListener(
-                                (ChannelAttachableListener & ObjectAttachableListener) listener);
-                    } else if (TextChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        removeTextChannelAttachableListener(
-                                (TextChannelAttachableListener & ObjectAttachableListener) listener);
-                    } else if (VoiceChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        removeVoiceChannelAttachableListener(
-                                (VoiceChannelAttachableListener & ObjectAttachableListener) listener);
-                    } else {
-                        ((ImplDiscordApi) getApi()).removeObjectListener(PrivateChannel.class, getId(),
-                                                                         listenerClass, listener);
-                    }
-                });
-    }
+    <T extends PrivateChannelAttachableListener & ObjectAttachableListener> void removePrivateChannelAttachableListener(
+            T listener);
 
     /**
      * Gets a map with all registered listeners that implement one or more {@code PrivateChannelAttachableListener}s and
@@ -135,34 +79,8 @@ public interface PrivateChannel extends TextChannel, VoiceChannel {
      * @return A map with all registered listeners that implement one or more {@code PrivateChannelAttachableListener}s
      * and their assigned listener classes they listen to.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends PrivateChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
-    getPrivateChannelAttachableListeners() {
-        Map<T, List<Class<T>>> privateChannelListeners =
-                ((ImplDiscordApi) getApi()).getObjectListeners(PrivateChannel.class, getId());
-        getTextChannelAttachableListeners().forEach((listener, listenerClasses) -> privateChannelListeners
-                .merge((T) listener,
-                       (List<Class<T>>) (Object) listenerClasses,
-                       (listenerClasses1, listenerClasses2) -> {
-                           listenerClasses1.addAll(listenerClasses2);
-                           return listenerClasses1;
-                       }));
-        getVoiceChannelAttachableListeners().forEach((listener, listenerClasses) -> privateChannelListeners
-                .merge((T) listener,
-                       (List<Class<T>>) (Object) listenerClasses,
-                       (listenerClasses1, listenerClasses2) -> {
-                           listenerClasses1.addAll(listenerClasses2);
-                           return listenerClasses1;
-                       }));
-        getChannelAttachableListeners().forEach((listener, listenerClasses) -> privateChannelListeners
-                .merge((T) listener,
-                       (List<Class<T>>) (Object) listenerClasses,
-                       (listenerClasses1, listenerClasses2) -> {
-                           listenerClasses1.addAll(listenerClasses2);
-                           return listenerClasses1;
-                       }));
-        return privateChannelListeners;
-    }
+    <T extends PrivateChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getPrivateChannelAttachableListeners();
 
     /**
      * Removes a listener from this private channel.
@@ -173,7 +91,6 @@ public interface PrivateChannel extends TextChannel, VoiceChannel {
      */
     default <T extends PrivateChannelAttachableListener & ObjectAttachableListener> void removeListener(
             Class<T> listenerClass, T listener) {
-        ((ImplDiscordApi) getApi()).removeObjectListener(PrivateChannel.class, getId(), listenerClass, listener);
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/entity/channel/ServerTextChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/ServerTextChannel.java
@@ -1,17 +1,12 @@
 package de.btobastian.javacord.entity.channel;
 
-import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entity.Mentionable;
 import de.btobastian.javacord.entity.webhook.WebhookBuilder;
-import de.btobastian.javacord.listener.ChannelAttachableListener;
 import de.btobastian.javacord.listener.ObjectAttachableListener;
-import de.btobastian.javacord.listener.TextChannelAttachableListener;
-import de.btobastian.javacord.listener.channel.server.ServerChannelAttachableListener;
 import de.btobastian.javacord.listener.channel.server.ServerChannelChangeNsfwFlagListener;
 import de.btobastian.javacord.listener.channel.server.text.ServerTextChannelAttachableListener;
 import de.btobastian.javacord.listener.channel.server.text.ServerTextChannelChangeTopicListener;
 import de.btobastian.javacord.listener.channel.text.WebhooksUpdateListener;
-import de.btobastian.javacord.util.ClassHelper;
 import de.btobastian.javacord.util.event.ListenerManager;
 
 import java.util.Collection;
@@ -20,8 +15,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This class represents a server text channel.
@@ -118,21 +111,15 @@ public interface ServerTextChannel extends ServerChannel, TextChannel, Mentionab
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<ServerTextChannelChangeTopicListener> addServerTextChannelChangeTopicListener(
-            ServerTextChannelChangeTopicListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                ServerTextChannel.class, getId(), ServerTextChannelChangeTopicListener.class, listener);
-    }
+    ListenerManager<ServerTextChannelChangeTopicListener> addServerTextChannelChangeTopicListener(
+            ServerTextChannelChangeTopicListener listener);
 
     /**
      * Gets a list with all registered server text channel change topic listeners.
      *
      * @return A list with all registered server text channel change topic listeners.
      */
-    default List<ServerTextChannelChangeTopicListener> getServerTextChannelChangeTopicListeners() {
-        return ((ImplDiscordApi) getApi())
-                .getObjectListeners(ServerTextChannel.class, getId(), ServerTextChannelChangeTopicListener.class);
-    }
+    List<ServerTextChannelChangeTopicListener> getServerTextChannelChangeTopicListeners();
 
     /**
      * Adds a listener, which listens to server channel nsfw flag changes of this channel.
@@ -140,21 +127,15 @@ public interface ServerTextChannel extends ServerChannel, TextChannel, Mentionab
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<ServerChannelChangeNsfwFlagListener> addServerChannelChangeNsfwFlagListener(
-            ServerChannelChangeNsfwFlagListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                ServerTextChannel.class, getId(), ServerChannelChangeNsfwFlagListener.class, listener);
-    }
+    ListenerManager<ServerChannelChangeNsfwFlagListener> addServerChannelChangeNsfwFlagListener(
+            ServerChannelChangeNsfwFlagListener listener);
 
     /**
      * Gets a list with all registered server channel change nsfw flag listeners.
      *
      * @return A list with all registered server channel change nsfw flag listeners.
      */
-    default List<ServerChannelChangeNsfwFlagListener> getServerChannelChangeNsfwFlagListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(
-                ServerTextChannel.class, getId(), ServerChannelChangeNsfwFlagListener.class);
-    }
+    List<ServerChannelChangeNsfwFlagListener> getServerChannelChangeNsfwFlagListeners();
 
     /**
      * Adds a listener, which listens to webhook updates of this channel.
@@ -162,20 +143,14 @@ public interface ServerTextChannel extends ServerChannel, TextChannel, Mentionab
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<WebhooksUpdateListener> addWebhooksUpdateListener(WebhooksUpdateListener listener) {
-        return ((ImplDiscordApi) getApi())
-                .addObjectListener(ServerTextChannel.class, getId(), WebhooksUpdateListener.class, listener);
-    }
+    ListenerManager<WebhooksUpdateListener> addWebhooksUpdateListener(WebhooksUpdateListener listener);
 
     /**
      * Gets a list with all registered webhooks update listeners.
      *
      * @return A list with all registered webhooks update listeners.
      */
-    default List<WebhooksUpdateListener> getWebhooksUpdateListeners() {
-        return ((ImplDiscordApi) getApi())
-                .getObjectListeners(ServerTextChannel.class, getId(), WebhooksUpdateListener.class);
-    }
+    List<WebhooksUpdateListener> getWebhooksUpdateListeners();
 
     /**
      * Adds a listener that implements one or more {@code ServerTextChannelAttachableListener}s.
@@ -187,31 +162,9 @@ public interface ServerTextChannel extends ServerChannel, TextChannel, Mentionab
      * @param <T> The type of the listener.
      * @return The managers for the added listener.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends ServerTextChannelAttachableListener & ObjectAttachableListener>
-    Collection<ListenerManager<? extends ServerTextChannelAttachableListener>>
-    addServerTextChannelAttachableListener(T listener) {
-        return ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(ServerTextChannelAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .flatMap(listenerClass -> {
-                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        return addChannelAttachableListener(
-                                (ChannelAttachableListener & ObjectAttachableListener) listener).stream();
-                    } else if (ServerChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        return addServerChannelAttachableListener(
-                                (ServerChannelAttachableListener & ObjectAttachableListener) listener).stream();
-                    } else if (TextChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        return addTextChannelAttachableListener(
-                                (TextChannelAttachableListener & ObjectAttachableListener) listener).stream();
-                    } else {
-                        return Stream.of(((ImplDiscordApi) getApi()).addObjectListener(ServerTextChannel.class, getId(),
-                                                                                       listenerClass, listener));
-                    }
-                })
-                .collect(Collectors.toList());
-    }
+    <T extends ServerTextChannelAttachableListener & ObjectAttachableListener>
+    Collection<ListenerManager<? extends ServerTextChannelAttachableListener>> addServerTextChannelAttachableListener(
+            T listener);
 
     /**
      * Removes a listener that implements one or more {@code ServerTextChannelAttachableListener}s.
@@ -219,29 +172,8 @@ public interface ServerTextChannel extends ServerChannel, TextChannel, Mentionab
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends ServerTextChannelAttachableListener & ObjectAttachableListener> void
-    removeServerTextChannelAttachableListener(T listener) {
-        ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(ServerTextChannelAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .forEach(listenerClass -> {
-                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        removeChannelAttachableListener(
-                                (ChannelAttachableListener & ObjectAttachableListener) listener);
-                    } else if (ServerChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        removeServerChannelAttachableListener(
-                                (ServerChannelAttachableListener & ObjectAttachableListener) listener);
-                    } else if (TextChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        removeTextChannelAttachableListener(
-                                (TextChannelAttachableListener & ObjectAttachableListener) listener);
-                    } else {
-                        ((ImplDiscordApi) getApi()).removeObjectListener(ServerTextChannel.class, getId(),
-                                                                         listenerClass, listener);
-                    }
-                });
-    }
+    <T extends ServerTextChannelAttachableListener & ObjectAttachableListener> void
+    removeServerTextChannelAttachableListener(T listener);
 
     /**
      * Gets a map with all registered listeners that implement one or more {@code ServerTextChannelAttachableListener}s
@@ -251,34 +183,8 @@ public interface ServerTextChannel extends ServerChannel, TextChannel, Mentionab
      * @return A map with all registered listeners that implement one or more
      * {@code ServerTextChannelAttachableListener}s and their assigned listener classes they listen to.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends ServerTextChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
-    getServerTextChannelAttachableListeners() {
-        Map<T, List<Class<T>>> serverTextChannelListeners =
-                ((ImplDiscordApi) getApi()).getObjectListeners(ServerTextChannel.class, getId());
-        getTextChannelAttachableListeners().forEach((listener, listenerClasses) -> serverTextChannelListeners
-                .merge((T) listener,
-                       (List<Class<T>>) (Object) listenerClasses,
-                       (listenerClasses1, listenerClasses2) -> {
-                           listenerClasses1.addAll(listenerClasses2);
-                           return listenerClasses1;
-                       }));
-        getServerChannelAttachableListeners().forEach((listener, listenerClasses) -> serverTextChannelListeners
-                .merge((T) listener,
-                       (List<Class<T>>) (Object) listenerClasses,
-                       (listenerClasses1, listenerClasses2) -> {
-                           listenerClasses1.addAll(listenerClasses2);
-                           return listenerClasses1;
-                       }));
-        getChannelAttachableListeners().forEach((listener, listenerClasses) -> serverTextChannelListeners
-                .merge((T) listener,
-                       (List<Class<T>>) (Object) listenerClasses,
-                       (listenerClasses1, listenerClasses2) -> {
-                           listenerClasses1.addAll(listenerClasses2);
-                           return listenerClasses1;
-                       }));
-        return serverTextChannelListeners;
-    }
+    <T extends ServerTextChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getServerTextChannelAttachableListeners();
 
     /**
      * Removes a listener from this server text channel.
@@ -289,7 +195,6 @@ public interface ServerTextChannel extends ServerChannel, TextChannel, Mentionab
      */
     default <T extends ServerTextChannelAttachableListener & ObjectAttachableListener> void removeListener(
             Class<T> listenerClass, T listener) {
-        ((ImplDiscordApi) getApi()).removeObjectListener(ServerTextChannel.class, getId(), listenerClass, listener);
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/entity/channel/ServerVoiceChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/ServerVoiceChannel.java
@@ -1,17 +1,12 @@
 package de.btobastian.javacord.entity.channel;
 
-import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entity.user.User;
-import de.btobastian.javacord.listener.ChannelAttachableListener;
 import de.btobastian.javacord.listener.ObjectAttachableListener;
-import de.btobastian.javacord.listener.VoiceChannelAttachableListener;
-import de.btobastian.javacord.listener.channel.server.ServerChannelAttachableListener;
 import de.btobastian.javacord.listener.channel.server.voice.ServerVoiceChannelAttachableListener;
 import de.btobastian.javacord.listener.channel.server.voice.ServerVoiceChannelChangeBitrateListener;
 import de.btobastian.javacord.listener.channel.server.voice.ServerVoiceChannelChangeUserLimitListener;
 import de.btobastian.javacord.listener.channel.server.voice.ServerVoiceChannelMemberJoinListener;
 import de.btobastian.javacord.listener.channel.server.voice.ServerVoiceChannelMemberLeaveListener;
-import de.btobastian.javacord.util.ClassHelper;
 import de.btobastian.javacord.util.event.ListenerManager;
 
 import java.util.Collection;
@@ -20,8 +15,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This class represents a server voice channel.
@@ -130,21 +123,15 @@ public interface ServerVoiceChannel extends ServerChannel, VoiceChannel, Categor
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<ServerVoiceChannelMemberJoinListener> addServerVoiceChannelMemberJoinListener(
-            ServerVoiceChannelMemberJoinListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                ServerVoiceChannel.class, getId(), ServerVoiceChannelMemberJoinListener.class, listener);
-    }
+    ListenerManager<ServerVoiceChannelMemberJoinListener> addServerVoiceChannelMemberJoinListener(
+            ServerVoiceChannelMemberJoinListener listener);
 
     /**
      * Gets a list with all registered server voice channel member join listeners.
      *
      * @return A list with all registered server voice channel member join listeners.
      */
-    default List<ServerVoiceChannelMemberJoinListener> getServerVoiceChannelMemberJoinListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(
-                ServerVoiceChannel.class, getId(), ServerVoiceChannelMemberJoinListener.class);
-    }
+    List<ServerVoiceChannelMemberJoinListener> getServerVoiceChannelMemberJoinListeners();
 
     /**
      * Adds a listener, which listens to users leaving this server voice channel.
@@ -152,21 +139,15 @@ public interface ServerVoiceChannel extends ServerChannel, VoiceChannel, Categor
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<ServerVoiceChannelMemberLeaveListener> addServerVoiceChannelMemberLeaveListener(
-            ServerVoiceChannelMemberLeaveListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                ServerVoiceChannel.class, getId(), ServerVoiceChannelMemberLeaveListener.class, listener);
-    }
+    ListenerManager<ServerVoiceChannelMemberLeaveListener> addServerVoiceChannelMemberLeaveListener(
+            ServerVoiceChannelMemberLeaveListener listener);
 
     /**
      * Gets a list with all registered server voice channel member leave listeners.
      *
      * @return A list with all registered server voice channel member leave listeners.
      */
-    default List<ServerVoiceChannelMemberLeaveListener> getServerVoiceChannelMemberLeaveListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(
-                ServerVoiceChannel.class, getId(), ServerVoiceChannelMemberLeaveListener.class);
-    }
+    List<ServerVoiceChannelMemberLeaveListener> getServerVoiceChannelMemberLeaveListeners();
 
     /**
      * Adds a listener, which listens to bitrate changes of this channel.
@@ -174,21 +155,15 @@ public interface ServerVoiceChannel extends ServerChannel, VoiceChannel, Categor
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<ServerVoiceChannelChangeBitrateListener> addServerVoiceChannelChangeBitrateListener(
-            ServerVoiceChannelChangeBitrateListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                ServerVoiceChannel.class, getId(), ServerVoiceChannelChangeBitrateListener.class, listener);
-    }
+    ListenerManager<ServerVoiceChannelChangeBitrateListener> addServerVoiceChannelChangeBitrateListener(
+            ServerVoiceChannelChangeBitrateListener listener);
 
     /**
      * Gets a list with all registered server voice channel change bitrate listeners.
      *
      * @return A list with all registered server voice channel change bitrate listeners.
      */
-    default List<ServerVoiceChannelChangeBitrateListener> getServerVoiceChannelChangeBitrateListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(
-                ServerVoiceChannel.class, getId(), ServerVoiceChannelChangeBitrateListener.class);
-    }
+    List<ServerVoiceChannelChangeBitrateListener> getServerVoiceChannelChangeBitrateListeners();
 
     /**
      * Adds a listener, which listens to user limit changes of this channel.
@@ -196,21 +171,15 @@ public interface ServerVoiceChannel extends ServerChannel, VoiceChannel, Categor
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<ServerVoiceChannelChangeUserLimitListener> addServerVoiceChannelChangeUserLimitListener(
-            ServerVoiceChannelChangeUserLimitListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                ServerVoiceChannel.class, getId(), ServerVoiceChannelChangeUserLimitListener.class, listener);
-    }
+    ListenerManager<ServerVoiceChannelChangeUserLimitListener> addServerVoiceChannelChangeUserLimitListener(
+            ServerVoiceChannelChangeUserLimitListener listener);
 
     /**
      * Gets a list with all registered server voice channel change user limit listeners.
      *
      * @return A list with all registered server voice channel change user limit listeners.
      */
-    default List<ServerVoiceChannelChangeUserLimitListener> getServerVoiceChannelChangeUserLimitListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(
-                ServerVoiceChannel.class, getId(), ServerVoiceChannelChangeUserLimitListener.class);
-    }
+    List<ServerVoiceChannelChangeUserLimitListener> getServerVoiceChannelChangeUserLimitListeners();
 
     /**
      * Adds a listener that implements one or more {@code ServerVoiceChannelAttachableListener}s.
@@ -222,31 +191,9 @@ public interface ServerVoiceChannel extends ServerChannel, VoiceChannel, Categor
      * @param <T> The type of the listener.
      * @return The managers for the added listener.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends ServerVoiceChannelAttachableListener & ObjectAttachableListener>
-    Collection<ListenerManager<? extends ServerVoiceChannelAttachableListener>>
-    addServerVoiceChannelAttachableListener(T listener) {
-        return ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(ServerVoiceChannelAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .flatMap(listenerClass -> {
-                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        return addChannelAttachableListener(
-                                (ChannelAttachableListener & ObjectAttachableListener) listener).stream();
-                    } else if (ServerChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        return addServerChannelAttachableListener(
-                                (ServerChannelAttachableListener & ObjectAttachableListener) listener).stream();
-                    } else if (VoiceChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        return addVoiceChannelAttachableListener(
-                                (VoiceChannelAttachableListener & ObjectAttachableListener) listener).stream();
-                    } else {
-                        return Stream.of(((ImplDiscordApi) getApi()).addObjectListener(
-                                ServerVoiceChannel.class, getId(), listenerClass, listener));
-                    }
-                })
-                .collect(Collectors.toList());
-    }
+    <T extends ServerVoiceChannelAttachableListener & ObjectAttachableListener>
+    Collection<ListenerManager<? extends ServerVoiceChannelAttachableListener>> addServerVoiceChannelAttachableListener(
+            T listener);
 
     /**
      * Removes a listener that implements one or more {@code ServerVoiceChannelAttachableListener}s.
@@ -254,29 +201,8 @@ public interface ServerVoiceChannel extends ServerChannel, VoiceChannel, Categor
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends ServerVoiceChannelAttachableListener & ObjectAttachableListener> void
-    removeServerVoiceChannelAttachableListener(T listener) {
-        ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(ServerVoiceChannelAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .forEach(listenerClass -> {
-                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        removeChannelAttachableListener(
-                                (ChannelAttachableListener & ObjectAttachableListener) listener);
-                    } else if (ServerChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        removeServerChannelAttachableListener(
-                                (ServerChannelAttachableListener & ObjectAttachableListener) listener);
-                    } else if (VoiceChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        removeVoiceChannelAttachableListener(
-                                (VoiceChannelAttachableListener & ObjectAttachableListener) listener);
-                    } else {
-                        ((ImplDiscordApi) getApi()).removeObjectListener(ServerVoiceChannel.class, getId(),
-                                                                         listenerClass, listener);
-                    }
-                });
-    }
+    <T extends ServerVoiceChannelAttachableListener & ObjectAttachableListener> void
+    removeServerVoiceChannelAttachableListener(T listener);
 
     /**
      * Gets a map with all registered listeners that implement one or more {@code ServerVoiceChannelAttachableListener}s
@@ -286,34 +212,8 @@ public interface ServerVoiceChannel extends ServerChannel, VoiceChannel, Categor
      * @return A map with all registered listeners that implement one or more
      * {@code ServerVoiceChannelAttachableListener}s and their assigned listener classes they listen to.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends ServerVoiceChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
-    getServerVoiceChannelAttachableListeners() {
-        Map<T, List<Class<T>>> serverVoiceChannelListeners =
-                ((ImplDiscordApi) getApi()).getObjectListeners(ServerVoiceChannel.class, getId());
-        getVoiceChannelAttachableListeners().forEach((listener, listenerClasses) -> serverVoiceChannelListeners
-                .merge((T) listener,
-                       (List<Class<T>>) (Object) listenerClasses,
-                       (listenerClasses1, listenerClasses2) -> {
-                           listenerClasses1.addAll(listenerClasses2);
-                           return listenerClasses1;
-                       }));
-        getServerChannelAttachableListeners().forEach((listener, listenerClasses) -> serverVoiceChannelListeners
-                .merge((T) listener,
-                       (List<Class<T>>) (Object) listenerClasses,
-                       (listenerClasses1, listenerClasses2) -> {
-                           listenerClasses1.addAll(listenerClasses2);
-                           return listenerClasses1;
-                       }));
-        getChannelAttachableListeners().forEach((listener, listenerClasses) -> serverVoiceChannelListeners
-                .merge((T) listener,
-                       (List<Class<T>>) (Object) listenerClasses,
-                       (listenerClasses1, listenerClasses2) -> {
-                           listenerClasses1.addAll(listenerClasses2);
-                           return listenerClasses1;
-                       }));
-        return serverVoiceChannelListeners;
-    }
+    <T extends ServerVoiceChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getServerVoiceChannelAttachableListeners();
 
     /**
      * Removes a listener from this server voice channel.
@@ -322,10 +222,8 @@ public interface ServerVoiceChannel extends ServerChannel, VoiceChannel, Categor
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    default <T extends ServerVoiceChannelAttachableListener & ObjectAttachableListener> void removeListener(
-            Class<T> listenerClass, T listener) {
-        ((ImplDiscordApi) getApi()).removeObjectListener(ServerVoiceChannel.class, getId(), listenerClass, listener);
-    }
+    <T extends ServerVoiceChannelAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener);
 
     @Override
     default Optional<ServerVoiceChannel> getCurrentCachedInstance() {

--- a/src/main/java/de/btobastian/javacord/entity/channel/TextChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/TextChannel.java
@@ -1,20 +1,12 @@
 package de.btobastian.javacord.entity.channel;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import de.btobastian.javacord.DiscordApi;
-import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entity.message.Message;
 import de.btobastian.javacord.entity.message.MessageSet;
 import de.btobastian.javacord.entity.message.Messageable;
-import de.btobastian.javacord.entity.message.impl.ImplMessageSet;
 import de.btobastian.javacord.entity.permission.PermissionType;
 import de.btobastian.javacord.entity.user.User;
 import de.btobastian.javacord.entity.webhook.Webhook;
-import de.btobastian.javacord.entity.webhook.impl.ImplWebhook;
-import de.btobastian.javacord.listener.ChannelAttachableListener;
 import de.btobastian.javacord.listener.ObjectAttachableListener;
 import de.btobastian.javacord.listener.TextChannelAttachableListener;
 import de.btobastian.javacord.listener.message.CachedMessagePinListener;
@@ -27,20 +19,14 @@ import de.btobastian.javacord.listener.message.reaction.ReactionAddListener;
 import de.btobastian.javacord.listener.message.reaction.ReactionRemoveAllListener;
 import de.btobastian.javacord.listener.message.reaction.ReactionRemoveListener;
 import de.btobastian.javacord.listener.user.UserStartTypingListener;
-import de.btobastian.javacord.util.ClassHelper;
 import de.btobastian.javacord.util.NonThrowingAutoCloseable;
 import de.btobastian.javacord.util.cache.MessageCache;
 import de.btobastian.javacord.util.event.ListenerManager;
 import de.btobastian.javacord.util.logging.LoggerUtil;
-import de.btobastian.javacord.util.rest.RestEndpoint;
-import de.btobastian.javacord.util.rest.RestMethod;
-import de.btobastian.javacord.util.rest.RestRequest;
 import org.slf4j.Logger;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -50,8 +36,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -76,12 +60,7 @@ public interface TextChannel extends Channel, Messageable {
      * @see #typeContinuously()
      * @see #typeContinuously(Consumer)
      */
-    default CompletableFuture<Void> type() {
-        return new RestRequest<Void>(getApi(), RestMethod.POST, RestEndpoint.CHANNEL_TYPING)
-                .setRatelimitRetries(0)
-                .setUrlParameters(getIdAsString())
-                .execute(result -> null);
-    }
+    CompletableFuture<Void> type();
 
     /**
      * Displays the "xyz is typing..." message continuously, starting immediately.
@@ -222,7 +201,7 @@ public interface TextChannel extends Channel, Messageable {
                 });
 
         // auto-closable to cancel the continuously typing indicator
-        return  () -> {
+        return () -> {
             typingInterruptedListenerManager.remove();
             typingIndicator.cancel(true);
         };
@@ -250,19 +229,7 @@ public interface TextChannel extends Channel, Messageable {
      * @param messageIds The ids of the messages to delete.
      * @return A future to tell us if the deletion was successful.
      */
-    default CompletableFuture<Void> bulkDelete(long... messageIds) {
-        ObjectNode body = JsonNodeFactory.instance.objectNode();
-        ArrayNode messages = body.putArray("messages");
-        LongStream.of(messageIds).boxed()
-                .map(Long::toUnsignedString)
-                .forEach(messages::add);
-
-        return new RestRequest<Void>(getApi(), RestMethod.POST, RestEndpoint.MESSAGES_BULK_DELETE)
-                .setRatelimitRetries(0)
-                .setUrlParameters(getIdAsString())
-                .setBody(body)
-                .execute(result -> null);
-    }
+    CompletableFuture<Void> bulkDelete(long... messageIds);
 
     /**
      * Deletes multiple messages at once.
@@ -366,13 +333,7 @@ public interface TextChannel extends Channel, Messageable {
      * @param id The id of the message.
      * @return The message with the given id.
      */
-    default CompletableFuture<Message> getMessageById(long id) {
-        return getApi().getCachedMessageById(id)
-                .map(CompletableFuture::completedFuture)
-                .orElseGet(() -> new RestRequest<Message>(getApi(), RestMethod.GET, RestEndpoint.MESSAGE)
-                .setUrlParameters(getIdAsString(), Long.toUnsignedString(id))
-                .execute(result -> ((ImplDiscordApi) getApi()).getOrCreateMessage(this, result.getJsonBody())));
-    }
+    CompletableFuture<Message> getMessageById(long id);
 
     /**
      * Gets a message by its id.
@@ -393,16 +354,7 @@ public interface TextChannel extends Channel, Messageable {
      *
      * @return A list with all pinned messages.
      */
-    default CompletableFuture<MessageSet> getPins() {
-        return new RestRequest<MessageSet>(getApi(), RestMethod.GET, RestEndpoint.PINS)
-                .setUrlParameters(getIdAsString())
-                .execute(result -> {
-                    Collection<Message> pins = StreamSupport.stream(result.getJsonBody().spliterator(), false)
-                            .map(pinJson -> ((ImplDiscordApi) getApi()).getOrCreateMessage(this, pinJson))
-                            .collect(Collectors.toList());
-                    return new ImplMessageSet(pins);
-                });
-    }
+    CompletableFuture<MessageSet> getPins();
 
     /**
      * Gets up to a given amount of messages in this channel from the newer end.
@@ -411,9 +363,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The messages.
      * @see #getMessagesAsStream()
      */
-    default CompletableFuture<MessageSet> getMessages(int limit) {
-        return ImplMessageSet.getMessages(this, limit);
-    }
+    CompletableFuture<MessageSet> getMessages(int limit);
 
     /**
      * Gets messages in this channel from the newer end until one that meets the given condition is found.
@@ -423,9 +373,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The messages.
      * @see #getMessagesAsStream()
      */
-    default CompletableFuture<MessageSet> getMessagesUntil(Predicate<Message> condition) {
-        return ImplMessageSet.getMessagesUntil(this, condition);
-    }
+    CompletableFuture<MessageSet> getMessagesUntil(Predicate<Message> condition);
 
     /**
      * Gets messages in this channel from the newer end while they meet the given condition.
@@ -435,9 +383,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The messages.
      * @see #getMessagesAsStream()
      */
-    default CompletableFuture<MessageSet> getMessagesWhile(Predicate<Message> condition) {
-        return ImplMessageSet.getMessagesWhile(this, condition);
-    }
+    CompletableFuture<MessageSet> getMessagesWhile(Predicate<Message> condition);
 
     /**
      * Gets a stream of messages in this channel sorted from newest to oldest.
@@ -448,9 +394,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The stream.
      * @see #getMessages(int)
      */
-    default Stream<Message> getMessagesAsStream() {
-        return ImplMessageSet.getMessagesAsStream(this);
-    }
+    Stream<Message> getMessagesAsStream();
 
     /**
      * Gets up to a given amount of messages in this channel before a given message in any channel.
@@ -460,9 +404,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The messages.
      * @see #getMessagesBeforeAsStream(long)
      */
-    default CompletableFuture<MessageSet> getMessagesBefore(int limit, long before) {
-        return ImplMessageSet.getMessagesBefore(this, limit, before);
-    }
+    CompletableFuture<MessageSet> getMessagesBefore(int limit, long before);
 
     /**
      * Gets messages in this channel before a given message in any channel until one that meets the given condition is
@@ -474,9 +416,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The messages.
      * @see #getMessagesBeforeAsStream(long)
      */
-    default CompletableFuture<MessageSet> getMessagesBeforeUntil(Predicate<Message> condition, long before) {
-        return ImplMessageSet.getMessagesBeforeUntil(this, condition, before);
-    }
+    CompletableFuture<MessageSet> getMessagesBeforeUntil(Predicate<Message> condition, long before);
 
     /**
      * Gets messages in this channel before a given message in any channel while they meet the given condition.
@@ -487,9 +427,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The messages.
      * @see #getMessagesBeforeAsStream(long)
      */
-    default CompletableFuture<MessageSet> getMessagesBeforeWhile(Predicate<Message> condition, long before) {
-        return ImplMessageSet.getMessagesBeforeWhile(this, condition, before);
-    }
+    CompletableFuture<MessageSet> getMessagesBeforeWhile(Predicate<Message> condition, long before);
 
     /**
      * Gets a stream of messages in this channel before a given message in any channel sorted from newest to oldest.
@@ -501,9 +439,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The stream.
      * @see #getMessagesBefore(int, long)
      */
-    default Stream<Message> getMessagesBeforeAsStream(long before) {
-        return ImplMessageSet.getMessagesBeforeAsStream(this, before);
-    }
+    Stream<Message> getMessagesBeforeAsStream(long before);
 
     /**
      * Gets up to a given amount of messages in this channel before a given message in any channel.
@@ -566,9 +502,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The messages.
      * @see #getMessagesAfterAsStream(long)
      */
-    default CompletableFuture<MessageSet> getMessagesAfter(int limit, long after) {
-        return ImplMessageSet.getMessagesAfter(this, limit, after);
-    }
+    CompletableFuture<MessageSet> getMessagesAfter(int limit, long after);
 
     /**
      * Gets messages in this channel after a given message in any channel until one that meets the given condition is
@@ -580,9 +514,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The messages.
      * @see #getMessagesAfterAsStream(long)
      */
-    default CompletableFuture<MessageSet> getMessagesAfterUntil(Predicate<Message> condition, long after) {
-        return ImplMessageSet.getMessagesAfterUntil(this, condition, after);
-    }
+    CompletableFuture<MessageSet> getMessagesAfterUntil(Predicate<Message> condition, long after);
 
     /**
      * Gets messages in this channel after a given message in any channel while they meet the given condition.
@@ -593,9 +525,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The messages.
      * @see #getMessagesAfterAsStream(long)
      */
-    default CompletableFuture<MessageSet> getMessagesAfterWhile(Predicate<Message> condition, long after) {
-        return ImplMessageSet.getMessagesAfterWhile(this, condition, after);
-    }
+    CompletableFuture<MessageSet> getMessagesAfterWhile(Predicate<Message> condition, long after);
 
     /**
      * Gets a stream of messages in this channel after a given message in any channel sorted from oldest to newest.
@@ -607,9 +537,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The messages.
      * @see #getMessagesAfter(int, long)
      */
-    default Stream<Message> getMessagesAfterAsStream(long after) {
-        return ImplMessageSet.getMessagesAfterAsStream(this, after);
-    }
+    Stream<Message> getMessagesAfterAsStream(long after);
 
     /**
      * Gets up to a given amount of messages in this channel after a given message in any channel.
@@ -677,9 +605,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The messages.
      * @see #getMessagesAroundAsStream(long)
      */
-    default CompletableFuture<MessageSet> getMessagesAround(int limit, long around) {
-        return ImplMessageSet.getMessagesAround(this, limit, around);
-    }
+    CompletableFuture<MessageSet> getMessagesAround(int limit, long around);
 
     /**
      * Gets messages in this channel around a given message in any channel until one that meets the given condition is
@@ -695,9 +621,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The messages.
      * @see #getMessagesAroundAsStream(long)
      */
-    default CompletableFuture<MessageSet> getMessagesAroundUntil(Predicate<Message> condition, long around) {
-        return ImplMessageSet.getMessagesAroundUntil(this, condition, around);
-    }
+    CompletableFuture<MessageSet> getMessagesAroundUntil(Predicate<Message> condition, long around);
 
     /**
      * Gets messages in this channel around a given message in any channel while they meet the given condition.
@@ -713,9 +637,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The messages.
      * @see #getMessagesAroundAsStream(long)
      */
-    default CompletableFuture<MessageSet> getMessagesAroundWhile(Predicate<Message> condition, long around) {
-        return ImplMessageSet.getMessagesAroundWhile(this, condition, around);
-    }
+    CompletableFuture<MessageSet> getMessagesAroundWhile(Predicate<Message> condition, long around);
 
     /**
      * Gets a stream of messages in this channel around a given message in any channel.
@@ -731,9 +653,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The stream.
      * @see #getMessagesAround(int, long)
      */
-    default Stream<Message> getMessagesAroundAsStream(long around) {
-        return ImplMessageSet.getMessagesAroundAsStream(this, around);
-    }
+    Stream<Message> getMessagesAroundAsStream(long around);
 
     /**
      * Gets up to a given amount of messages in this channel around a given message in any channel.
@@ -815,9 +735,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The messages.
      * @see #getMessagesBetweenAsStream(long, long)
      */
-    default CompletableFuture<MessageSet> getMessagesBetween(long from, long to) {
-        return ImplMessageSet.getMessagesBetween(this, from, to);
-    }
+    CompletableFuture<MessageSet> getMessagesBetween(long from, long to);
 
     /**
      * Gets all messages in this channel between the first given message in any channel and the second given message in
@@ -830,9 +748,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The messages.
      * @see #getMessagesBetweenAsStream(long, long)
      */
-    default CompletableFuture<MessageSet> getMessagesBetweenUntil(Predicate<Message> condition, long from, long to) {
-        return ImplMessageSet.getMessagesBetweenUntil(this, condition, from, to);
-    }
+    CompletableFuture<MessageSet> getMessagesBetweenUntil(Predicate<Message> condition, long from, long to);
 
     /**
      * Gets all messages in this channel between the first given message in any channel and the second given message in
@@ -845,9 +761,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The messages.
      * @see #getMessagesBetweenAsStream(long, long)
      */
-    default CompletableFuture<MessageSet> getMessagesBetweenWhile(Predicate<Message> condition, long from, long to) {
-        return ImplMessageSet.getMessagesBetweenWhile(this, condition, from, to);
-    }
+    CompletableFuture<MessageSet> getMessagesBetweenWhile(Predicate<Message> condition, long from, long to);
 
     /**
      * Gets all messages in this channel between the first given message in any channel and the second given message in
@@ -861,9 +775,7 @@ public interface TextChannel extends Channel, Messageable {
      * @return The stream.
      * @see #getMessagesBetween(long, long)
      */
-    default Stream<Message> getMessagesBetweenAsStream(long from, long to) {
-        return ImplMessageSet.getMessagesBetweenAsStream(this, from, to);
-    }
+    Stream<Message> getMessagesBetweenAsStream(long from, long to);
 
     /**
      * Gets all messages in this channel between the first given message in any channel and the second given message in
@@ -938,17 +850,7 @@ public interface TextChannel extends Channel, Messageable {
      *
      * @return A list of all webhooks in this channel.
      */
-    default CompletableFuture<List<Webhook>> getWebhooks() {
-        return new RestRequest<List<Webhook>>(getApi(), RestMethod.GET, RestEndpoint.CHANNEL_WEBHOOK)
-                .setUrlParameters(getIdAsString())
-                .execute(result -> {
-                    List<Webhook> webhooks = new ArrayList<>();
-                    for (JsonNode webhook : result.getJsonBody()) {
-                        webhooks.add(new ImplWebhook(getApi(), webhook));
-                    }
-                    return Collections.unmodifiableList(webhooks);
-                });
-    }
+    CompletableFuture<List<Webhook>> getWebhooks();
 
     /**
      * Checks if the given user can send messages in this channel.
@@ -970,9 +872,9 @@ public interface TextChannel extends Channel, Messageable {
         }
         Optional<ServerTextChannel> severTextChannel = asServerTextChannel();
         return !severTextChannel.isPresent()
-                || severTextChannel.get().hasPermission(user, PermissionType.ADMINISTRATOR)
-                || severTextChannel.get()
-                .hasPermissions(user, PermissionType.READ_MESSAGES, PermissionType.SEND_MESSAGES);
+               || severTextChannel.get().hasPermission(user, PermissionType.ADMINISTRATOR)
+               || severTextChannel.get()
+                       .hasPermissions(user, PermissionType.READ_MESSAGES, PermissionType.SEND_MESSAGES);
     }
 
     /**
@@ -1003,9 +905,9 @@ public interface TextChannel extends Channel, Messageable {
         }
         Optional<ServerTextChannel> severTextChannel = asServerTextChannel();
         return !severTextChannel.isPresent()
-                || severTextChannel.get().hasAnyPermission(user,
-                                                           PermissionType.ADMINISTRATOR,
-                                                           PermissionType.USE_EXTERNAL_EMOJIS);
+               || severTextChannel.get().hasAnyPermission(user,
+                                                          PermissionType.ADMINISTRATOR,
+                                                          PermissionType.USE_EXTERNAL_EMOJIS);
     }
 
     /**
@@ -1036,9 +938,9 @@ public interface TextChannel extends Channel, Messageable {
         }
         Optional<ServerTextChannel> severTextChannel = asServerTextChannel();
         return !severTextChannel.isPresent()
-                || severTextChannel.get().hasAnyPermission(user,
-                                                           PermissionType.ADMINISTRATOR,
-                                                           PermissionType.EMBED_LINKS);
+               || severTextChannel.get().hasAnyPermission(user,
+                                                          PermissionType.ADMINISTRATOR,
+                                                          PermissionType.EMBED_LINKS);
     }
 
     /**
@@ -1067,9 +969,9 @@ public interface TextChannel extends Channel, Messageable {
         }
         Optional<ServerTextChannel> severTextChannel = asServerTextChannel();
         return !severTextChannel.isPresent()
-                || severTextChannel.get().hasAnyPermission(user,
-                                                           PermissionType.ADMINISTRATOR,
-                                                           PermissionType.READ_MESSAGE_HISTORY);
+               || severTextChannel.get().hasAnyPermission(user,
+                                                          PermissionType.ADMINISTRATOR,
+                                                          PermissionType.READ_MESSAGE_HISTORY);
     }
 
     /**
@@ -1098,9 +1000,9 @@ public interface TextChannel extends Channel, Messageable {
         }
         Optional<ServerTextChannel> severTextChannel = asServerTextChannel();
         return !severTextChannel.isPresent()
-                || severTextChannel.get().hasAnyPermission(user,
-                                                           PermissionType.ADMINISTRATOR,
-                                                           PermissionType.SEND_TTS_MESSAGES);
+               || severTextChannel.get().hasAnyPermission(user,
+                                                          PermissionType.ADMINISTRATOR,
+                                                          PermissionType.SEND_TTS_MESSAGES);
     }
 
     /**
@@ -1132,9 +1034,9 @@ public interface TextChannel extends Channel, Messageable {
         }
         Optional<ServerTextChannel> severTextChannel = asServerTextChannel();
         return !severTextChannel.isPresent()
-                || severTextChannel.get().hasPermission(user, PermissionType.ADMINISTRATOR)
-                || (severTextChannel.get().hasPermission(user, PermissionType.ATTACH_FILE)
-                && severTextChannel.get().canWrite(user));
+               || severTextChannel.get().hasPermission(user, PermissionType.ADMINISTRATOR)
+               || (severTextChannel.get().hasPermission(user, PermissionType.ATTACH_FILE)
+                   && severTextChannel.get().canWrite(user));
     }
 
     /**
@@ -1163,11 +1065,11 @@ public interface TextChannel extends Channel, Messageable {
         }
         Optional<ServerTextChannel> severTextChannel = asServerTextChannel();
         return !severTextChannel.isPresent()
-                || severTextChannel.get().hasPermission(user, PermissionType.ADMINISTRATOR)
-                || severTextChannel.get().hasPermissions(user,
-                PermissionType.READ_MESSAGES,
-                PermissionType.READ_MESSAGE_HISTORY,
-                PermissionType.ADD_REACTIONS);
+               || severTextChannel.get().hasPermission(user, PermissionType.ADMINISTRATOR)
+               || severTextChannel.get().hasPermissions(user,
+                                                        PermissionType.READ_MESSAGES,
+                                                        PermissionType.READ_MESSAGE_HISTORY,
+                                                        PermissionType.ADD_REACTIONS);
     }
 
     /**
@@ -1193,9 +1095,9 @@ public interface TextChannel extends Channel, Messageable {
         }
         Optional<ServerTextChannel> severTextChannel = asServerTextChannel();
         return !severTextChannel.isPresent()
-                || severTextChannel.get().hasAnyPermission(user,
-                                                           PermissionType.ADMINISTRATOR,
-                                                           PermissionType.MANAGE_MESSAGES);
+               || severTextChannel.get().hasAnyPermission(user,
+                                                          PermissionType.ADMINISTRATOR,
+                                                          PermissionType.MANAGE_MESSAGES);
     }
 
     /**
@@ -1247,9 +1149,9 @@ public interface TextChannel extends Channel, Messageable {
         }
         Optional<ServerTextChannel> severTextChannel = asServerTextChannel();
         return !severTextChannel.isPresent()
-                || severTextChannel.get().hasPermission(user, PermissionType.ADMINISTRATOR)
-                || (severTextChannel.get().hasPermission(user, PermissionType.MENTION_EVERYONE)
-                && severTextChannel.get().canWrite(user));
+               || severTextChannel.get().hasPermission(user, PermissionType.ADMINISTRATOR)
+               || (severTextChannel.get().hasPermission(user, PermissionType.MENTION_EVERYONE)
+                   && severTextChannel.get().canWrite(user));
     }
 
     /**
@@ -1269,19 +1171,14 @@ public interface TextChannel extends Channel, Messageable {
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<MessageCreateListener> addMessageCreateListener(MessageCreateListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                TextChannel.class, getId(), MessageCreateListener.class, listener);
-    }
+    ListenerManager<MessageCreateListener> addMessageCreateListener(MessageCreateListener listener);
 
     /**
      * Gets a list with all registered message create listeners.
      *
      * @return A list with all registered message create listeners.
      */
-    default List<MessageCreateListener> getMessageCreateListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(TextChannel.class, getId(), MessageCreateListener.class);
-    }
+    List<MessageCreateListener> getMessageCreateListeners();
 
     /**
      * Adds a listener, which listens to users starting to type in this channel.
@@ -1289,20 +1186,14 @@ public interface TextChannel extends Channel, Messageable {
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<UserStartTypingListener> addUserStartTypingListener(UserStartTypingListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                TextChannel.class, getId(), UserStartTypingListener.class, listener);
-    }
+    ListenerManager<UserStartTypingListener> addUserStartTypingListener(UserStartTypingListener listener);
 
     /**
      * Gets a list with all registered user starts typing listeners.
      *
      * @return A list with all registered user starts typing listeners.
      */
-    default List<UserStartTypingListener> getUserStartTypingListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(
-                TextChannel.class, getId(), UserStartTypingListener.class);
-    }
+    List<UserStartTypingListener> getUserStartTypingListeners();
 
     /**
      * Adds a listener, which listens to message deletions in this channel.
@@ -1310,19 +1201,14 @@ public interface TextChannel extends Channel, Messageable {
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<MessageDeleteListener> addMessageDeleteListener(MessageDeleteListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                TextChannel.class, getId(), MessageDeleteListener.class, listener);
-    }
+    ListenerManager<MessageDeleteListener> addMessageDeleteListener(MessageDeleteListener listener);
 
     /**
      * Gets a list with all registered message delete listeners.
      *
      * @return A list with all registered message delete listeners.
      */
-    default List<MessageDeleteListener> getMessageDeleteListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(TextChannel.class, getId(), MessageDeleteListener.class);
-    }
+    List<MessageDeleteListener> getMessageDeleteListeners();
 
     /**
      * Adds a listener, which listens to message edits in this channel.
@@ -1330,19 +1216,14 @@ public interface TextChannel extends Channel, Messageable {
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<MessageEditListener> addMessageEditListener(MessageEditListener listener) {
-        return ((ImplDiscordApi) getApi())
-                .addObjectListener(TextChannel.class, getId(), MessageEditListener.class, listener);
-    }
+    ListenerManager<MessageEditListener> addMessageEditListener(MessageEditListener listener);
 
     /**
      * Gets a list with all registered message edit listeners.
      *
      * @return A list with all registered message edit listeners.
      */
-    default List<MessageEditListener> getMessageEditListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(TextChannel.class, getId(), MessageEditListener.class);
-    }
+    List<MessageEditListener> getMessageEditListeners();
 
     /**
      * Adds a listener, which listens to reactions being added in this channel.
@@ -1350,19 +1231,14 @@ public interface TextChannel extends Channel, Messageable {
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<ReactionAddListener> addReactionAddListener(ReactionAddListener listener) {
-        return ((ImplDiscordApi) getApi())
-                .addObjectListener(TextChannel.class, getId(), ReactionAddListener.class, listener);
-    }
+    ListenerManager<ReactionAddListener> addReactionAddListener(ReactionAddListener listener);
 
     /**
      * Gets a list with all registered reaction add listeners.
      *
      * @return A list with all registered reaction add listeners.
      */
-    default List<ReactionAddListener> getReactionAddListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(TextChannel.class, getId(), ReactionAddListener.class);
-    }
+    List<ReactionAddListener> getReactionAddListeners();
 
     /**
      * Adds a listener, which listens to reactions being removed in this channel.
@@ -1370,19 +1246,14 @@ public interface TextChannel extends Channel, Messageable {
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<ReactionRemoveListener> addReactionRemoveListener(ReactionRemoveListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                TextChannel.class, getId(), ReactionRemoveListener.class, listener);
-    }
+    ListenerManager<ReactionRemoveListener> addReactionRemoveListener(ReactionRemoveListener listener);
 
     /**
      * Gets a list with all registered reaction remove listeners.
      *
      * @return A list with all registered reaction remove listeners.
      */
-    default List<ReactionRemoveListener> getReactionRemoveListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(TextChannel.class, getId(), ReactionRemoveListener.class);
-    }
+    List<ReactionRemoveListener> getReactionRemoveListeners();
 
     /**
      * Adds a listener, which listens to all reactions being removed at once from a message in this channel.
@@ -1390,21 +1261,14 @@ public interface TextChannel extends Channel, Messageable {
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<ReactionRemoveAllListener> addReactionRemoveAllListener(
-            ReactionRemoveAllListener listener) {
-        return ((ImplDiscordApi) getApi())
-                .addObjectListener(TextChannel.class, getId(), ReactionRemoveAllListener.class, listener);
-    }
+    ListenerManager<ReactionRemoveAllListener> addReactionRemoveAllListener(ReactionRemoveAllListener listener);
 
     /**
      * Gets a list with all registered reaction remove all listeners.
      *
      * @return A list with all registered reaction remove all listeners.
      */
-    default List<ReactionRemoveAllListener> getReactionRemoveAllListeners() {
-        return ((ImplDiscordApi) getApi())
-                .getObjectListeners(TextChannel.class, getId(), ReactionRemoveAllListener.class);
-    }
+    List<ReactionRemoveAllListener> getReactionRemoveAllListeners();
 
     /**
      * Adds a listener, which listens to all pin updates in this channel.
@@ -1412,21 +1276,14 @@ public interface TextChannel extends Channel, Messageable {
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<ChannelPinsUpdateListener> addChannelPinsUpdateListener(
-            ChannelPinsUpdateListener listener) {
-        return ((ImplDiscordApi) getApi())
-                .addObjectListener(TextChannel.class, getId(), ChannelPinsUpdateListener.class, listener);
-    }
+    ListenerManager<ChannelPinsUpdateListener> addChannelPinsUpdateListener(ChannelPinsUpdateListener listener);
 
     /**
      * Gets a list with all registered channel pins update listeners.
      *
      * @return A list with all registered channel pins update listeners.
      */
-    default List<ChannelPinsUpdateListener> getChannelPinsUpdateListeners() {
-        return ((ImplDiscordApi) getApi())
-                .getObjectListeners(TextChannel.class, getId(), ChannelPinsUpdateListener.class);
-    }
+    List<ChannelPinsUpdateListener> getChannelPinsUpdateListeners();
 
     /**
      * Adds a listener, which listens to all cached message pins in this channel.
@@ -1434,20 +1291,14 @@ public interface TextChannel extends Channel, Messageable {
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<CachedMessagePinListener> addCachedMessagePinListener(CachedMessagePinListener listener) {
-        return ((ImplDiscordApi) getApi())
-                .addObjectListener(TextChannel.class, getId(), CachedMessagePinListener.class, listener);
-    }
+    ListenerManager<CachedMessagePinListener> addCachedMessagePinListener(CachedMessagePinListener listener);
 
     /**
      * Gets a list with all registered cached message pin listeners.
      *
      * @return A list with all registered cached message pin listeners.
      */
-    default List<CachedMessagePinListener> getCachedMessagePinListeners() {
-        return ((ImplDiscordApi) getApi())
-                .getObjectListeners(TextChannel.class, getId(), CachedMessagePinListener.class);
-    }
+    List<CachedMessagePinListener> getCachedMessagePinListeners();
 
     /**
      * Adds a listener, which listens to all cached message unpins in this channel.
@@ -1455,21 +1306,14 @@ public interface TextChannel extends Channel, Messageable {
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<CachedMessageUnpinListener> addCachedMessageUnpinListener(
-            CachedMessageUnpinListener listener) {
-        return ((ImplDiscordApi) getApi())
-                .addObjectListener(TextChannel.class, getId(), CachedMessageUnpinListener.class, listener);
-    }
+    ListenerManager<CachedMessageUnpinListener> addCachedMessageUnpinListener(CachedMessageUnpinListener listener);
 
     /**
      * Gets a list with all registered cached message unpin listeners.
      *
      * @return A list with all registered cached message unpin listeners.
      */
-    default List<CachedMessageUnpinListener> getCachedMessageUnpinListeners() {
-        return ((ImplDiscordApi) getApi())
-                .getObjectListeners(TextChannel.class, getId(), CachedMessageUnpinListener.class);
-    }
+    List<CachedMessageUnpinListener> getCachedMessageUnpinListeners();
 
     /**
      * Adds a listener that implements one or more {@code TextChannelAttachableListener}s.
@@ -1482,24 +1326,8 @@ public interface TextChannel extends Channel, Messageable {
      * @return The managers for the added listener.
      */
     @SuppressWarnings("unchecked")
-    default <T extends TextChannelAttachableListener & ObjectAttachableListener>
-    Collection<ListenerManager<? extends TextChannelAttachableListener>>
-    addTextChannelAttachableListener(T listener) {
-        return ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(TextChannelAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .flatMap(listenerClass -> {
-                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        return addChannelAttachableListener(
-                                (ChannelAttachableListener & ObjectAttachableListener) listener).stream();
-                    } else {
-                        return Stream.of(((ImplDiscordApi) getApi()).addObjectListener(TextChannel.class, getId(),
-                                                                                       listenerClass, listener));
-                    }
-                })
-                .collect(Collectors.toList());
-    }
+    <T extends TextChannelAttachableListener & ObjectAttachableListener>
+    Collection<ListenerManager<? extends TextChannelAttachableListener>> addTextChannelAttachableListener(T listener);
 
     /**
      * Removes a listener that implements one or more {@code TextChannelAttachableListener}s.
@@ -1508,22 +1336,8 @@ public interface TextChannel extends Channel, Messageable {
      * @param <T> The type of the listener.
      */
     @SuppressWarnings("unchecked")
-    default <T extends TextChannelAttachableListener & ObjectAttachableListener> void
-    removeTextChannelAttachableListener(T listener) {
-        ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(TextChannelAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .forEach(listenerClass -> {
-                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        removeChannelAttachableListener(
-                                (ChannelAttachableListener & ObjectAttachableListener) listener);
-                    } else {
-                        ((ImplDiscordApi) getApi()).removeObjectListener(TextChannel.class, getId(),
-                                                                         listenerClass, listener);
-                    }
-                });
-    }
+    <T extends TextChannelAttachableListener & ObjectAttachableListener> void removeTextChannelAttachableListener(
+            T listener);
 
     /**
      * Gets a map with all registered listeners that implement one or more {@code TextChannelAttachableListener}s and
@@ -1534,19 +1348,8 @@ public interface TextChannel extends Channel, Messageable {
      * their assigned listener classes they listen to.
      */
     @SuppressWarnings("unchecked")
-    default <T extends TextChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
-    getTextChannelAttachableListeners() {
-        Map<T, List<Class<T>>> textChannelListeners =
-                ((ImplDiscordApi) getApi()).getObjectListeners(TextChannel.class, getId());
-        getChannelAttachableListeners().forEach((listener, listenerClasses) -> textChannelListeners
-                .merge((T) listener,
-                       (List<Class<T>>) (Object) listenerClasses,
-                       (listenerClasses1, listenerClasses2) -> {
-                           listenerClasses1.addAll(listenerClasses2);
-                           return listenerClasses1;
-                       }));
-        return textChannelListeners;
-    }
+    <T extends TextChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getTextChannelAttachableListeners();
 
     /**
      * Removes a listener from this text channel.
@@ -1555,10 +1358,8 @@ public interface TextChannel extends Channel, Messageable {
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    default <T extends TextChannelAttachableListener & ObjectAttachableListener> void removeListener(
-            Class<T> listenerClass, T listener) {
-        ((ImplDiscordApi) getApi()).removeObjectListener(TextChannel.class, getId(), listenerClass, listener);
-    }
+    <T extends TextChannelAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener);
 
     @Override
     default Optional<? extends TextChannel> getCurrentCachedInstance() {

--- a/src/main/java/de/btobastian/javacord/entity/channel/VoiceChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/VoiceChannel.java
@@ -1,12 +1,9 @@
 package de.btobastian.javacord.entity.channel;
 
-import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entity.permission.PermissionType;
 import de.btobastian.javacord.entity.user.User;
-import de.btobastian.javacord.listener.ChannelAttachableListener;
 import de.btobastian.javacord.listener.ObjectAttachableListener;
 import de.btobastian.javacord.listener.VoiceChannelAttachableListener;
-import de.btobastian.javacord.util.ClassHelper;
 import de.btobastian.javacord.util.event.ListenerManager;
 
 import java.util.Collection;
@@ -15,8 +12,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This class represents a voice channel.
@@ -37,9 +32,9 @@ public interface VoiceChannel extends Channel {
         }
         Optional<ServerTextChannel> severTextChannel = asServerTextChannel();
         return !severTextChannel.isPresent()
-                || severTextChannel.get().hasAnyPermission(user,
-                                                           PermissionType.ADMINISTRATOR,
-                                                           PermissionType.VOICE_CONNECT);
+               || severTextChannel.get().hasAnyPermission(user,
+                                                          PermissionType.ADMINISTRATOR,
+                                                          PermissionType.VOICE_CONNECT);
     }
 
     /**
@@ -66,9 +61,9 @@ public interface VoiceChannel extends Channel {
         }
         Optional<ServerVoiceChannel> serverVoiceChannel = asServerVoiceChannel();
         return !serverVoiceChannel.isPresent()
-                || serverVoiceChannel.get().hasAnyPermission(user,
-                                                             PermissionType.ADMINISTRATOR,
-                                                             PermissionType.VOICE_MUTE_MEMBERS);
+               || serverVoiceChannel.get().hasAnyPermission(user,
+                                                            PermissionType.ADMINISTRATOR,
+                                                            PermissionType.VOICE_MUTE_MEMBERS);
     }
 
     /**
@@ -91,25 +86,8 @@ public interface VoiceChannel extends Channel {
      * @param <T> The type of the listener.
      * @return The managers for the added listener.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends VoiceChannelAttachableListener & ObjectAttachableListener>
-    Collection<ListenerManager<? extends VoiceChannelAttachableListener>>
-    addVoiceChannelAttachableListener(T listener) {
-        return ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(VoiceChannelAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .flatMap(listenerClass -> {
-                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        return addChannelAttachableListener(
-                                (ChannelAttachableListener & ObjectAttachableListener) listener).stream();
-                    } else {
-                        return Stream.of(((ImplDiscordApi) getApi()).addObjectListener(VoiceChannel.class, getId(),
-                                                                                       listenerClass, listener));
-                    }
-                })
-                .collect(Collectors.toList());
-    }
+    <T extends VoiceChannelAttachableListener & ObjectAttachableListener>
+    Collection<ListenerManager<? extends VoiceChannelAttachableListener>> addVoiceChannelAttachableListener(T listener);
 
     /**
      * Removes a listener that implements one or more {@code VoiceChannelAttachableListener}s.
@@ -117,23 +95,8 @@ public interface VoiceChannel extends Channel {
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends VoiceChannelAttachableListener & ObjectAttachableListener> void
-    removeVoiceChannelAttachableListener(T listener) {
-        ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(VoiceChannelAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .forEach(listenerClass -> {
-                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
-                        removeChannelAttachableListener(
-                                (ChannelAttachableListener & ObjectAttachableListener) listener);
-                    } else {
-                        ((ImplDiscordApi) getApi()).removeObjectListener(VoiceChannel.class, getId(),
-                                                                         listenerClass, listener);
-                    }
-                });
-    }
+    <T extends VoiceChannelAttachableListener & ObjectAttachableListener> void removeVoiceChannelAttachableListener(
+            T listener);
 
     /**
      * Gets a map with all registered listeners that implement one or more {@code VoiceChannelAttachableListener}s and
@@ -143,20 +106,8 @@ public interface VoiceChannel extends Channel {
      * @return A map with all registered listeners that implement one or more {@code VoiceChannelAttachableListener}s
      * and their assigned listener classes they listen to.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends VoiceChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
-    getVoiceChannelAttachableListeners() {
-        Map<T, List<Class<T>>> voiceChannelListeners =
-                ((ImplDiscordApi) getApi()).getObjectListeners(VoiceChannel.class, getId());
-        getChannelAttachableListeners().forEach((listener, listenerClasses) -> voiceChannelListeners
-                .merge((T) listener,
-                       (List<Class<T>>) (Object) listenerClasses,
-                       (listenerClasses1, listenerClasses2) -> {
-                           listenerClasses1.addAll(listenerClasses2);
-                           return listenerClasses1;
-                       }));
-        return voiceChannelListeners;
-    }
+    <T extends VoiceChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getVoiceChannelAttachableListeners();
 
     /**
      * Removes a listener from this voice channel.
@@ -165,10 +116,8 @@ public interface VoiceChannel extends Channel {
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    default <T extends VoiceChannelAttachableListener & ObjectAttachableListener> void removeListener(
-            Class<T> listenerClass, T listener) {
-        ((ImplDiscordApi) getApi()).removeObjectListener(VoiceChannel.class, getId(), listenerClass, listener);
-    }
+    <T extends VoiceChannelAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener);
 
     @Override
     default Optional<? extends VoiceChannel> getCurrentCachedInstance() {

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplChannelCategory.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplChannelCategory.java
@@ -5,6 +5,7 @@ import de.btobastian.javacord.DiscordApi;
 import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entity.DiscordEntity;
 import de.btobastian.javacord.entity.channel.ChannelCategory;
+import de.btobastian.javacord.entity.channel.InternalChannel;
 import de.btobastian.javacord.entity.channel.ServerChannelUpdater;
 import de.btobastian.javacord.entity.permission.Permissions;
 import de.btobastian.javacord.entity.permission.Role;
@@ -19,7 +20,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * The implementation of {@link ChannelCategory}.
  */
-public class ImplChannelCategory implements ChannelCategory {
+public class ImplChannelCategory implements ChannelCategory, InternalChannel {
 
     /**
      * The discord api instance.

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplChannelCategory.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplChannelCategory.java
@@ -6,6 +6,7 @@ import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entity.DiscordEntity;
 import de.btobastian.javacord.entity.channel.ChannelCategory;
 import de.btobastian.javacord.entity.channel.InternalChannel;
+import de.btobastian.javacord.entity.channel.InternalServerChannel;
 import de.btobastian.javacord.entity.channel.ServerChannel;
 import de.btobastian.javacord.entity.channel.ServerChannelUpdater;
 import de.btobastian.javacord.entity.channel.ServerTextChannel;
@@ -37,7 +38,7 @@ import java.util.stream.Stream;
 /**
  * The implementation of {@link ChannelCategory}.
  */
-public class ImplChannelCategory implements ChannelCategory, InternalChannel {
+public class ImplChannelCategory implements ChannelCategory, InternalChannel, InternalServerChannel {
 
     /**
      * The discord api instance.

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplChannelCategory.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplChannelCategory.java
@@ -6,16 +6,33 @@ import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entity.DiscordEntity;
 import de.btobastian.javacord.entity.channel.ChannelCategory;
 import de.btobastian.javacord.entity.channel.InternalChannel;
+import de.btobastian.javacord.entity.channel.ServerChannel;
 import de.btobastian.javacord.entity.channel.ServerChannelUpdater;
+import de.btobastian.javacord.entity.channel.ServerTextChannel;
 import de.btobastian.javacord.entity.permission.Permissions;
 import de.btobastian.javacord.entity.permission.Role;
 import de.btobastian.javacord.entity.permission.impl.ImplPermissions;
 import de.btobastian.javacord.entity.server.Server;
 import de.btobastian.javacord.entity.server.impl.ImplServer;
 import de.btobastian.javacord.entity.user.User;
+import de.btobastian.javacord.listener.ChannelAttachableListener;
+import de.btobastian.javacord.listener.ObjectAttachableListener;
+import de.btobastian.javacord.listener.channel.server.ChannelCategoryAttachableListener;
+import de.btobastian.javacord.listener.channel.server.ServerChannelAttachableListener;
+import de.btobastian.javacord.listener.channel.server.ServerChannelChangeNsfwFlagListener;
+import de.btobastian.javacord.util.ClassHelper;
+import de.btobastian.javacord.util.event.ListenerManager;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * The implementation of {@link ChannelCategory}.
@@ -154,8 +171,112 @@ public class ImplChannelCategory implements ChannelCategory, InternalChannel {
     }
 
     @Override
+    public List<ServerChannel> getChannels() {
+        List<ServerChannel> channels = new ArrayList<>();
+        ((ImplServer) getServer()).getUnorderedChannels().stream()
+                .filter(channel -> channel.asServerTextChannel().isPresent())
+                .map(channel -> channel.asServerTextChannel().get())
+                .filter(channel -> channel.getCategory().orElse(null) == this)
+                .sorted(Comparator.comparingInt(ServerChannel::getRawPosition))
+                .forEach(channels::add);
+        ((ImplServer) getServer()).getUnorderedChannels().stream()
+                .filter(channel -> channel.asServerVoiceChannel().isPresent())
+                .map(channel -> channel.asServerVoiceChannel().get())
+                .filter(channel -> channel.getCategory().orElse(null) == this)
+                .sorted(Comparator.comparingInt(ServerChannel::getRawPosition))
+                .forEach(channels::add);
+        return Collections.unmodifiableList(channels);
+    }
+
+    @Override
     public boolean isNsfw() {
         return nsfw;
+    }
+
+    @Override
+    public ListenerManager<ServerChannelChangeNsfwFlagListener> addServerChannelChangeNsfwFlagListener(
+            ServerChannelChangeNsfwFlagListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                ServerTextChannel.class, getId(), ServerChannelChangeNsfwFlagListener.class, listener);
+    }
+
+    @Override
+    public List<ServerChannelChangeNsfwFlagListener> getServerChannelChangeNsfwFlagListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                ServerTextChannel.class, getId(), ServerChannelChangeNsfwFlagListener.class);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends ChannelCategoryAttachableListener & ObjectAttachableListener>
+    Collection<ListenerManager<? extends ChannelCategoryAttachableListener>> addChannelCategoryAttachableListener(
+            T listener) {
+        return ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(ChannelCategoryAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .flatMap(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else if (ServerChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addServerChannelAttachableListener(
+                                (ServerChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else {
+                        return Stream.of(((ImplDiscordApi) getApi()).addObjectListener(ChannelCategory.class, getId(),
+                                                                                       listenerClass, listener));
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends ChannelCategoryAttachableListener & ObjectAttachableListener> void removeChannelCategoryAttachableListener(T listener) {
+        ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(ChannelCategoryAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .forEach(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else if (ServerChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeServerChannelAttachableListener(
+                                (ServerChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else {
+                        ((ImplDiscordApi) getApi()).removeObjectListener(ChannelCategory.class, getId(),
+                                                                         listenerClass, listener);
+                    }
+                });
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends ChannelCategoryAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>> getChannelCategoryAttachableListeners() {
+        Map<T, List<Class<T>>> channelCategoryListeners =
+                ((ImplDiscordApi) getApi()).getObjectListeners(ChannelCategory.class, getId());
+        getServerChannelAttachableListeners().forEach((listener, listenerClasses) -> channelCategoryListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        getChannelAttachableListeners().forEach((listener, listenerClasses) -> channelCategoryListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        return channelCategoryListeners;
+    }
+
+    @Override
+    public <T extends ChannelCategoryAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(ChannelCategory.class, getId(), listenerClass, listener);
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplGroupChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplGroupChannel.java
@@ -7,6 +7,7 @@ import de.btobastian.javacord.entity.DiscordEntity;
 import de.btobastian.javacord.entity.Icon;
 import de.btobastian.javacord.entity.channel.GroupChannel;
 import de.btobastian.javacord.entity.channel.GroupChannelUpdater;
+import de.btobastian.javacord.entity.channel.InternalChannel;
 import de.btobastian.javacord.entity.impl.ImplIcon;
 import de.btobastian.javacord.entity.user.User;
 import de.btobastian.javacord.util.Cleanupable;
@@ -27,7 +28,7 @@ import java.util.Optional;
 /**
  * The implementation of {@link GroupChannel}.
  */
-public class ImplGroupChannel implements GroupChannel, Cleanupable {
+public class ImplGroupChannel implements GroupChannel, Cleanupable, InternalChannel {
 
     /**
      * The logger of this class.

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplGroupChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplGroupChannel.java
@@ -9,6 +9,7 @@ import de.btobastian.javacord.entity.channel.GroupChannel;
 import de.btobastian.javacord.entity.channel.GroupChannelUpdater;
 import de.btobastian.javacord.entity.channel.InternalChannel;
 import de.btobastian.javacord.entity.channel.InternalTextChannel;
+import de.btobastian.javacord.entity.channel.InternalVoiceChannel;
 import de.btobastian.javacord.entity.impl.ImplIcon;
 import de.btobastian.javacord.entity.user.User;
 import de.btobastian.javacord.listener.ChannelAttachableListener;
@@ -41,7 +42,8 @@ import java.util.stream.Stream;
 /**
  * The implementation of {@link GroupChannel}.
  */
-public class ImplGroupChannel implements GroupChannel, Cleanupable, InternalChannel, InternalTextChannel {
+public class ImplGroupChannel
+        implements GroupChannel, Cleanupable, InternalChannel, InternalTextChannel, InternalVoiceChannel {
 
     /**
      * The logger of this class.

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplGroupChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplGroupChannel.java
@@ -10,9 +10,18 @@ import de.btobastian.javacord.entity.channel.GroupChannelUpdater;
 import de.btobastian.javacord.entity.channel.InternalChannel;
 import de.btobastian.javacord.entity.impl.ImplIcon;
 import de.btobastian.javacord.entity.user.User;
+import de.btobastian.javacord.listener.ChannelAttachableListener;
+import de.btobastian.javacord.listener.ObjectAttachableListener;
+import de.btobastian.javacord.listener.TextChannelAttachableListener;
+import de.btobastian.javacord.listener.VoiceChannelAttachableListener;
+import de.btobastian.javacord.listener.channel.group.GroupChannelAttachableListener;
+import de.btobastian.javacord.listener.channel.group.GroupChannelChangeNameListener;
+import de.btobastian.javacord.listener.channel.group.GroupChannelDeleteListener;
+import de.btobastian.javacord.util.ClassHelper;
 import de.btobastian.javacord.util.Cleanupable;
 import de.btobastian.javacord.util.cache.ImplMessageCache;
 import de.btobastian.javacord.util.cache.MessageCache;
+import de.btobastian.javacord.util.event.ListenerManager;
 import de.btobastian.javacord.util.logging.LoggerUtil;
 import org.slf4j.Logger;
 
@@ -22,8 +31,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * The implementation of {@link GroupChannel}.
@@ -140,6 +152,120 @@ public class ImplGroupChannel implements GroupChannel, Cleanupable, InternalChan
     @Override
     public GroupChannelUpdater createUpdater() {
         return new ImplGroupChannelUpdater(this);
+    }
+
+    @Override
+    public ListenerManager<GroupChannelChangeNameListener> addGroupChannelChangeNameListener(
+            GroupChannelChangeNameListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                GroupChannel.class, getId(), GroupChannelChangeNameListener.class, listener);
+    }
+
+    @Override
+    public List<GroupChannelChangeNameListener> getGroupChannelChangeNameListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                GroupChannel.class, getId(), GroupChannelChangeNameListener.class);
+    }
+
+    @Override
+    public ListenerManager<GroupChannelDeleteListener> addGroupChannelDeleteListener(
+            GroupChannelDeleteListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                GroupChannel.class, getId(), GroupChannelDeleteListener.class, listener);
+    }
+
+    @Override
+    public List<GroupChannelDeleteListener> getGroupChannelDeleteListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                GroupChannel.class, getId(), GroupChannelDeleteListener.class);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends GroupChannelAttachableListener & ObjectAttachableListener>
+    Collection<ListenerManager<? extends GroupChannelAttachableListener>> addGroupChannelAttachableListener(
+            T listener) {
+        return ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(GroupChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .flatMap(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else if (TextChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addTextChannelAttachableListener(
+                                (TextChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else if (VoiceChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addVoiceChannelAttachableListener(
+                                (VoiceChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else {
+                        return Stream.of(((ImplDiscordApi) getApi()).addObjectListener(GroupChannel.class, getId(),
+                                                                                       listenerClass, listener));
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends GroupChannelAttachableListener & ObjectAttachableListener> void
+    removeGroupChannelAttachableListener(T listener) {
+        ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(GroupChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .forEach(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else if (TextChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeTextChannelAttachableListener(
+                                (TextChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else if (VoiceChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeVoiceChannelAttachableListener(
+                                (VoiceChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else {
+                        ((ImplDiscordApi) getApi()).removeObjectListener(GroupChannel.class, getId(),
+                                                                         listenerClass, listener);
+                    }
+                });
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends GroupChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getGroupChannelAttachableListeners() {
+        Map<T, List<Class<T>>> groupChannelListeners =
+                ((ImplDiscordApi) getApi()).getObjectListeners(GroupChannel.class, getId());
+        getTextChannelAttachableListeners().forEach((listener, listenerClasses) -> groupChannelListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        getVoiceChannelAttachableListeners().forEach((listener, listenerClasses) -> groupChannelListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        getChannelAttachableListeners().forEach((listener, listenerClasses) -> groupChannelListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        return groupChannelListeners;
+    }
+
+    @Override
+    public <T extends GroupChannelAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(GroupChannel.class, getId(), listenerClass, listener);
     }
 
     @Override

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplGroupChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplGroupChannel.java
@@ -8,6 +8,7 @@ import de.btobastian.javacord.entity.Icon;
 import de.btobastian.javacord.entity.channel.GroupChannel;
 import de.btobastian.javacord.entity.channel.GroupChannelUpdater;
 import de.btobastian.javacord.entity.channel.InternalChannel;
+import de.btobastian.javacord.entity.channel.InternalTextChannel;
 import de.btobastian.javacord.entity.impl.ImplIcon;
 import de.btobastian.javacord.entity.user.User;
 import de.btobastian.javacord.listener.ChannelAttachableListener;
@@ -40,7 +41,7 @@ import java.util.stream.Stream;
 /**
  * The implementation of {@link GroupChannel}.
  */
-public class ImplGroupChannel implements GroupChannel, Cleanupable, InternalChannel {
+public class ImplGroupChannel implements GroupChannel, Cleanupable, InternalChannel, InternalTextChannel {
 
     /**
      * The logger of this class.

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplPrivateChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplPrivateChannel.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import de.btobastian.javacord.DiscordApi;
 import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entity.DiscordEntity;
+import de.btobastian.javacord.entity.channel.InternalChannel;
 import de.btobastian.javacord.entity.channel.PrivateChannel;
 import de.btobastian.javacord.entity.user.User;
 import de.btobastian.javacord.entity.user.impl.ImplUser;
@@ -16,7 +17,7 @@ import java.util.Objects;
 /**
  * The implementation of {@link PrivateChannel}.
  */
-public class ImplPrivateChannel implements PrivateChannel, Cleanupable {
+public class ImplPrivateChannel implements PrivateChannel, Cleanupable, InternalChannel {
 
     /**
      * The discord api instance.

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplPrivateChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplPrivateChannel.java
@@ -8,11 +8,24 @@ import de.btobastian.javacord.entity.channel.InternalChannel;
 import de.btobastian.javacord.entity.channel.PrivateChannel;
 import de.btobastian.javacord.entity.user.User;
 import de.btobastian.javacord.entity.user.impl.ImplUser;
+import de.btobastian.javacord.listener.ChannelAttachableListener;
+import de.btobastian.javacord.listener.ObjectAttachableListener;
+import de.btobastian.javacord.listener.TextChannelAttachableListener;
+import de.btobastian.javacord.listener.VoiceChannelAttachableListener;
+import de.btobastian.javacord.listener.user.channel.PrivateChannelAttachableListener;
+import de.btobastian.javacord.listener.user.channel.PrivateChannelDeleteListener;
+import de.btobastian.javacord.util.ClassHelper;
 import de.btobastian.javacord.util.Cleanupable;
 import de.btobastian.javacord.util.cache.ImplMessageCache;
 import de.btobastian.javacord.util.cache.MessageCache;
+import de.btobastian.javacord.util.event.ListenerManager;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * The implementation of {@link PrivateChannel}.
@@ -71,10 +84,110 @@ public class ImplPrivateChannel implements PrivateChannel, Cleanupable, Internal
     }
 
     @Override
+    public ListenerManager<PrivateChannelDeleteListener> addPrivateChannelDeleteListener(
+            PrivateChannelDeleteListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                PrivateChannel.class, getId(), PrivateChannelDeleteListener.class, listener);
+    }
+
+    @Override
+    public List<PrivateChannelDeleteListener> getPrivateChannelDeleteListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                PrivateChannel.class, getId(), PrivateChannelDeleteListener.class);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends PrivateChannelAttachableListener & ObjectAttachableListener>
+    Collection<ListenerManager<? extends PrivateChannelAttachableListener>> addPrivateChannelAttachableListener(
+            T listener) {
+        return ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(PrivateChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .flatMap(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else if (TextChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addTextChannelAttachableListener(
+                                (TextChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else if (VoiceChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addVoiceChannelAttachableListener(
+                                (VoiceChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else {
+                        return Stream.of(((ImplDiscordApi) getApi()).addObjectListener(PrivateChannel.class, getId(),
+                                                                                       listenerClass, listener));
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends PrivateChannelAttachableListener & ObjectAttachableListener> void
+    removePrivateChannelAttachableListener(T listener) {
+        ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(PrivateChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .forEach(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else if (TextChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeTextChannelAttachableListener(
+                                (TextChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else if (VoiceChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeVoiceChannelAttachableListener(
+                                (VoiceChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else {
+                        ((ImplDiscordApi) getApi()).removeObjectListener(PrivateChannel.class, getId(),
+                                                                         listenerClass, listener);
+                    }
+                });
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends PrivateChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getPrivateChannelAttachableListeners() {
+        Map<T, List<Class<T>>> privateChannelListeners =
+                ((ImplDiscordApi) getApi()).getObjectListeners(PrivateChannel.class, getId());
+        getTextChannelAttachableListeners().forEach((listener, listenerClasses) -> privateChannelListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        getVoiceChannelAttachableListeners().forEach((listener, listenerClasses) -> privateChannelListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        getChannelAttachableListeners().forEach((listener, listenerClasses) -> privateChannelListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        return privateChannelListeners;
+    }
+
+    @Override
+    public <T extends PrivateChannelAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(PrivateChannel.class, getId(), listenerClass, listener);
+    }
+
+    @Override
     public MessageCache getMessageCache() {
         return messageCache;
     }
-
 
     @Override
     public void cleanup() {

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplPrivateChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplPrivateChannel.java
@@ -6,6 +6,7 @@ import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entity.DiscordEntity;
 import de.btobastian.javacord.entity.channel.InternalChannel;
 import de.btobastian.javacord.entity.channel.InternalTextChannel;
+import de.btobastian.javacord.entity.channel.InternalVoiceChannel;
 import de.btobastian.javacord.entity.channel.PrivateChannel;
 import de.btobastian.javacord.entity.user.User;
 import de.btobastian.javacord.entity.user.impl.ImplUser;
@@ -31,7 +32,8 @@ import java.util.stream.Stream;
 /**
  * The implementation of {@link PrivateChannel}.
  */
-public class ImplPrivateChannel implements PrivateChannel, Cleanupable, InternalChannel, InternalTextChannel {
+public class ImplPrivateChannel
+        implements PrivateChannel, Cleanupable, InternalChannel, InternalTextChannel, InternalVoiceChannel {
 
     /**
      * The discord api instance.

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplPrivateChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplPrivateChannel.java
@@ -5,6 +5,7 @@ import de.btobastian.javacord.DiscordApi;
 import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entity.DiscordEntity;
 import de.btobastian.javacord.entity.channel.InternalChannel;
+import de.btobastian.javacord.entity.channel.InternalTextChannel;
 import de.btobastian.javacord.entity.channel.PrivateChannel;
 import de.btobastian.javacord.entity.user.User;
 import de.btobastian.javacord.entity.user.impl.ImplUser;
@@ -30,7 +31,7 @@ import java.util.stream.Stream;
 /**
  * The implementation of {@link PrivateChannel}.
  */
-public class ImplPrivateChannel implements PrivateChannel, Cleanupable, InternalChannel {
+public class ImplPrivateChannel implements PrivateChannel, Cleanupable, InternalChannel, InternalTextChannel {
 
     /**
      * The discord api instance.

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplServerTextChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplServerTextChannel.java
@@ -6,6 +6,7 @@ import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entity.DiscordEntity;
 import de.btobastian.javacord.entity.channel.ChannelCategory;
 import de.btobastian.javacord.entity.channel.InternalChannel;
+import de.btobastian.javacord.entity.channel.InternalServerChannel;
 import de.btobastian.javacord.entity.channel.ServerTextChannel;
 import de.btobastian.javacord.entity.channel.ServerTextChannelUpdater;
 import de.btobastian.javacord.entity.permission.Permissions;
@@ -27,7 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * The implementation of {@link ServerTextChannel}.
  */
-public class ImplServerTextChannel implements ServerTextChannel, Cleanupable, InternalChannel {
+public class ImplServerTextChannel implements ServerTextChannel, Cleanupable, InternalChannel, InternalServerChannel {
 
     /**
      * The discord api instance.

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplServerTextChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplServerTextChannel.java
@@ -5,6 +5,7 @@ import de.btobastian.javacord.DiscordApi;
 import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entity.DiscordEntity;
 import de.btobastian.javacord.entity.channel.ChannelCategory;
+import de.btobastian.javacord.entity.channel.InternalChannel;
 import de.btobastian.javacord.entity.channel.ServerTextChannel;
 import de.btobastian.javacord.entity.channel.ServerTextChannelUpdater;
 import de.btobastian.javacord.entity.permission.Permissions;
@@ -26,7 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * The implementation of {@link ServerTextChannel}.
  */
-public class ImplServerTextChannel implements ServerTextChannel, Cleanupable {
+public class ImplServerTextChannel implements ServerTextChannel, Cleanupable, InternalChannel {
 
     /**
      * The discord api instance.

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplServerTextChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplServerTextChannel.java
@@ -7,6 +7,7 @@ import de.btobastian.javacord.entity.DiscordEntity;
 import de.btobastian.javacord.entity.channel.ChannelCategory;
 import de.btobastian.javacord.entity.channel.InternalChannel;
 import de.btobastian.javacord.entity.channel.InternalServerChannel;
+import de.btobastian.javacord.entity.channel.InternalTextChannel;
 import de.btobastian.javacord.entity.channel.ServerTextChannel;
 import de.btobastian.javacord.entity.channel.ServerTextChannelUpdater;
 import de.btobastian.javacord.entity.permission.Permissions;
@@ -43,7 +44,8 @@ import java.util.stream.Stream;
 /**
  * The implementation of {@link ServerTextChannel}.
  */
-public class ImplServerTextChannel implements ServerTextChannel, Cleanupable, InternalChannel, InternalServerChannel {
+public class ImplServerTextChannel
+        implements ServerTextChannel, Cleanupable, InternalChannel, InternalServerChannel, InternalTextChannel {
 
     /**
      * The discord api instance.

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplServerVoiceChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplServerVoiceChannel.java
@@ -7,6 +7,7 @@ import de.btobastian.javacord.entity.DiscordEntity;
 import de.btobastian.javacord.entity.channel.ChannelCategory;
 import de.btobastian.javacord.entity.channel.InternalChannel;
 import de.btobastian.javacord.entity.channel.InternalServerChannel;
+import de.btobastian.javacord.entity.channel.InternalVoiceChannel;
 import de.btobastian.javacord.entity.channel.ServerVoiceChannel;
 import de.btobastian.javacord.entity.channel.ServerVoiceChannelUpdater;
 import de.btobastian.javacord.entity.permission.Permissions;
@@ -41,7 +42,8 @@ import java.util.stream.Stream;
 /**
  * The implementation of {@link ServerVoiceChannel}.
  */
-public class ImplServerVoiceChannel implements ServerVoiceChannel, InternalChannel, InternalServerChannel {
+public class ImplServerVoiceChannel
+        implements ServerVoiceChannel, InternalChannel, InternalServerChannel, InternalVoiceChannel {
 
     /**
      * The discord api instance.

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplServerVoiceChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplServerVoiceChannel.java
@@ -6,6 +6,7 @@ import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entity.DiscordEntity;
 import de.btobastian.javacord.entity.channel.ChannelCategory;
 import de.btobastian.javacord.entity.channel.InternalChannel;
+import de.btobastian.javacord.entity.channel.InternalServerChannel;
 import de.btobastian.javacord.entity.channel.ServerVoiceChannel;
 import de.btobastian.javacord.entity.channel.ServerVoiceChannelUpdater;
 import de.btobastian.javacord.entity.permission.Permissions;
@@ -25,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * The implementation of {@link ServerVoiceChannel}.
  */
-public class ImplServerVoiceChannel implements ServerVoiceChannel, InternalChannel {
+public class ImplServerVoiceChannel implements ServerVoiceChannel, InternalChannel, InternalServerChannel {
 
     /**
      * The discord api instance.

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplServerVoiceChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplServerVoiceChannel.java
@@ -5,6 +5,7 @@ import de.btobastian.javacord.DiscordApi;
 import de.btobastian.javacord.ImplDiscordApi;
 import de.btobastian.javacord.entity.DiscordEntity;
 import de.btobastian.javacord.entity.channel.ChannelCategory;
+import de.btobastian.javacord.entity.channel.InternalChannel;
 import de.btobastian.javacord.entity.channel.ServerVoiceChannel;
 import de.btobastian.javacord.entity.channel.ServerVoiceChannelUpdater;
 import de.btobastian.javacord.entity.permission.Permissions;
@@ -24,7 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * The implementation of {@link ServerVoiceChannel}.
  */
-public class ImplServerVoiceChannel implements ServerVoiceChannel {
+public class ImplServerVoiceChannel implements ServerVoiceChannel, InternalChannel {
 
     /**
      * The discord api instance.

--- a/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplServerVoiceChannel.java
+++ b/src/main/java/de/btobastian/javacord/entity/channel/impl/ImplServerVoiceChannel.java
@@ -15,13 +15,28 @@ import de.btobastian.javacord.entity.permission.impl.ImplPermissions;
 import de.btobastian.javacord.entity.server.Server;
 import de.btobastian.javacord.entity.server.impl.ImplServer;
 import de.btobastian.javacord.entity.user.User;
+import de.btobastian.javacord.listener.ChannelAttachableListener;
+import de.btobastian.javacord.listener.ObjectAttachableListener;
+import de.btobastian.javacord.listener.VoiceChannelAttachableListener;
+import de.btobastian.javacord.listener.channel.server.ServerChannelAttachableListener;
+import de.btobastian.javacord.listener.channel.server.voice.ServerVoiceChannelAttachableListener;
+import de.btobastian.javacord.listener.channel.server.voice.ServerVoiceChannelChangeBitrateListener;
+import de.btobastian.javacord.listener.channel.server.voice.ServerVoiceChannelChangeUserLimitListener;
+import de.btobastian.javacord.listener.channel.server.voice.ServerVoiceChannelMemberJoinListener;
+import de.btobastian.javacord.listener.channel.server.voice.ServerVoiceChannelMemberLeaveListener;
+import de.btobastian.javacord.util.ClassHelper;
+import de.btobastian.javacord.util.event.ListenerManager;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * The implementation of {@link ServerVoiceChannel}.
@@ -259,6 +274,146 @@ public class ImplServerVoiceChannel implements ServerVoiceChannel, InternalChann
     @Override
     public ServerVoiceChannelUpdater createUpdater() {
         return new ImplServerVoiceChannelUpdater(this);
+    }
+
+    @Override
+    public ListenerManager<ServerVoiceChannelMemberJoinListener> addServerVoiceChannelMemberJoinListener(
+            ServerVoiceChannelMemberJoinListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                ServerVoiceChannel.class, getId(), ServerVoiceChannelMemberJoinListener.class, listener);
+    }
+
+    @Override
+    public List<ServerVoiceChannelMemberJoinListener> getServerVoiceChannelMemberJoinListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                ServerVoiceChannel.class, getId(), ServerVoiceChannelMemberJoinListener.class);
+    }
+
+    @Override
+    public ListenerManager<ServerVoiceChannelMemberLeaveListener> addServerVoiceChannelMemberLeaveListener(
+            ServerVoiceChannelMemberLeaveListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                ServerVoiceChannel.class, getId(), ServerVoiceChannelMemberLeaveListener.class, listener);
+    }
+
+    @Override
+    public List<ServerVoiceChannelMemberLeaveListener> getServerVoiceChannelMemberLeaveListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                ServerVoiceChannel.class, getId(), ServerVoiceChannelMemberLeaveListener.class);
+    }
+
+    @Override
+    public ListenerManager<ServerVoiceChannelChangeBitrateListener> addServerVoiceChannelChangeBitrateListener(
+            ServerVoiceChannelChangeBitrateListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                ServerVoiceChannel.class, getId(), ServerVoiceChannelChangeBitrateListener.class, listener);
+    }
+
+    @Override
+    public List<ServerVoiceChannelChangeBitrateListener> getServerVoiceChannelChangeBitrateListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                ServerVoiceChannel.class, getId(), ServerVoiceChannelChangeBitrateListener.class);
+    }
+
+    @Override
+    public ListenerManager<ServerVoiceChannelChangeUserLimitListener> addServerVoiceChannelChangeUserLimitListener(
+            ServerVoiceChannelChangeUserLimitListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                ServerVoiceChannel.class, getId(), ServerVoiceChannelChangeUserLimitListener.class, listener);
+    }
+
+    @Override
+    public List<ServerVoiceChannelChangeUserLimitListener> getServerVoiceChannelChangeUserLimitListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                ServerVoiceChannel.class, getId(), ServerVoiceChannelChangeUserLimitListener.class);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends ServerVoiceChannelAttachableListener & ObjectAttachableListener>
+    Collection<ListenerManager<? extends ServerVoiceChannelAttachableListener>> addServerVoiceChannelAttachableListener(
+            T listener) {
+        return ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(ServerVoiceChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .flatMap(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else if (ServerChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addServerChannelAttachableListener(
+                                (ServerChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else if (VoiceChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        return addVoiceChannelAttachableListener(
+                                (VoiceChannelAttachableListener & ObjectAttachableListener) listener).stream();
+                    } else {
+                        return Stream.of(((ImplDiscordApi) getApi()).addObjectListener(
+                                ServerVoiceChannel.class, getId(), listenerClass, listener));
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends ServerVoiceChannelAttachableListener & ObjectAttachableListener> void
+    removeServerVoiceChannelAttachableListener(T listener) {
+        ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(ServerVoiceChannelAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .forEach(listenerClass -> {
+                    if (ChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeChannelAttachableListener(
+                                (ChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else if (ServerChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeServerChannelAttachableListener(
+                                (ServerChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else if (VoiceChannelAttachableListener.class.isAssignableFrom(listenerClass)) {
+                        removeVoiceChannelAttachableListener(
+                                (VoiceChannelAttachableListener & ObjectAttachableListener) listener);
+                    } else {
+                        ((ImplDiscordApi) getApi()).removeObjectListener(ServerVoiceChannel.class, getId(),
+                                                                         listenerClass, listener);
+                    }
+                });
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends ServerVoiceChannelAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getServerVoiceChannelAttachableListeners() {
+        Map<T, List<Class<T>>> serverVoiceChannelListeners =
+                ((ImplDiscordApi) getApi()).getObjectListeners(ServerVoiceChannel.class, getId());
+        getVoiceChannelAttachableListeners().forEach((listener, listenerClasses) -> serverVoiceChannelListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        getServerChannelAttachableListeners().forEach((listener, listenerClasses) -> serverVoiceChannelListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        getChannelAttachableListeners().forEach((listener, listenerClasses) -> serverVoiceChannelListeners
+                .merge((T) listener,
+                       (List<Class<T>>) (Object) listenerClasses,
+                       (listenerClasses1, listenerClasses2) -> {
+                           listenerClasses1.addAll(listenerClasses2);
+                           return listenerClasses1;
+                       }));
+        return serverVoiceChannelListeners;
+    }
+
+    @Override
+    public <T extends ServerVoiceChannelAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(ServerVoiceChannel.class, getId(), listenerClass, listener);
     }
 
     @Override


### PR DESCRIPTION
This is how it would look like with way 4
The InternalChannel will be part of the core package
We could actually also call it ImplChannel, as that is actually its role
But I don't know how you like calling an interface impl even if that is its role in that case