### PR TITLE
Centralize the service loader logic

### DIFF
--- a/src/main/java/org/javacord/DiscordApiBuilder.java
+++ b/src/main/java/org/javacord/DiscordApiBuilder.java
@@ -1,6 +1,7 @@
 package org.javacord;
 
 import org.javacord.event.server.ServerBecomesAvailableEvent;
+import org.javacord.util.FactoryBuilder;
 import org.javacord.util.logging.LoggerUtil;
 import org.slf4j.Logger;
 
@@ -28,23 +29,7 @@ public class DiscordApiBuilder {
     /**
      * The factory used to create a {@link DiscordApi} instance.
      */
-    private DiscordApiFactory factory;
-
-    /**
-     * Creates a new discord api builder.
-     */
-    public DiscordApiBuilder() {
-        ServiceLoader<DiscordApiFactory> factoryServiceLoader = ServiceLoader.load(DiscordApiFactory.class);
-        Iterator<DiscordApiFactory> factoryIterator = factoryServiceLoader.iterator();
-        if (factoryIterator.hasNext()) {
-            factory = factoryIterator.next();
-            if (factoryIterator.hasNext()) {
-                throw new IllegalStateException("Found more than one DiscordApiFactory implementation!");
-            }
-        } else {
-            throw new IllegalStateException("No DiscordApiFactory implementation was found!");
-        }
-    }
+    private DiscordApiFactory factory = FactoryBuilder.createDiscordApiFactory();
 
     /**
      * Login to the account with the given token.

--- a/src/main/java/org/javacord/entity/message/MessageBuilder.java
+++ b/src/main/java/org/javacord/entity/message/MessageBuilder.java
@@ -5,6 +5,7 @@ import org.javacord.entity.Mentionable;
 import org.javacord.entity.channel.TextChannel;
 import org.javacord.entity.message.embed.EmbedBuilder;
 import org.javacord.entity.user.User;
+import org.javacord.util.FactoryBuilder;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -20,35 +21,9 @@ import java.util.concurrent.CompletableFuture;
 public class MessageBuilder {
 
     /**
-     * The base factory. It's only used to create new factories.
-     */
-    private static final MessageFactory baseFactory;
-
-    // Load it static, because it has a better performance to load it only once
-    static {
-        ServiceLoader<MessageFactory> factoryServiceLoader = ServiceLoader.load(MessageFactory.class);
-        Iterator<MessageFactory> factoryIterator = factoryServiceLoader.iterator();
-        if (factoryIterator.hasNext()) {
-            baseFactory = factoryIterator.next();
-            if (factoryIterator.hasNext()) {
-                throw new IllegalStateException("Found more than one MessageFactory implementation!");
-            }
-        } else {
-            throw new IllegalStateException("No MessageFactory implementation was found!");
-        }
-    }
-
-    /**
      * The message factory used by this instance.
      */
-    private final MessageFactory factory;
-
-    /**
-     * Creates a new message builder.
-     */
-    public MessageBuilder() {
-        factory = baseFactory.getNewInstance();
-    }
+    private final MessageFactory factory = FactoryBuilder.createMessageFactory();
 
     /**
      * Creates a message builder from a message.

--- a/src/main/java/org/javacord/entity/message/MessageFactory.java
+++ b/src/main/java/org/javacord/entity/message/MessageFactory.java
@@ -18,14 +18,6 @@ import java.util.concurrent.CompletableFuture;
 public interface MessageFactory {
 
     /**
-     * Gets a new instance of a message factory.
-     * This method is the same as calling the constructor of the implementation.
-     *
-     * @return A new instance of a message factory.
-     */
-    MessageFactory getNewInstance();
-
-    /**
      * Appends a sting with or without decoration to the message.
      *
      * @param message The string to append.

--- a/src/main/java/org/javacord/entity/message/embed/EmbedBuilder.java
+++ b/src/main/java/org/javacord/entity/message/embed/EmbedBuilder.java
@@ -3,6 +3,8 @@ package org.javacord.entity.message.embed;
 import org.javacord.entity.Icon;
 import org.javacord.entity.message.MessageAuthor;
 import org.javacord.entity.user.User;
+import org.javacord.util.FactoryBuilder;
+import org.javacord.util.FactoryBuilderDelegate;
 
 import java.awt.Color;
 import java.awt.image.BufferedImage;
@@ -18,35 +20,9 @@ import java.util.ServiceLoader;
 public class EmbedBuilder {
 
     /**
-     * The base factory. It's only used to create new factories.
-     */
-    private static final EmbedFactory baseFactory;
-
-    // Load it static, because it has a better performance to load it only once
-    static {
-        ServiceLoader<EmbedFactory> factoryServiceLoader = ServiceLoader.load(EmbedFactory.class);
-        Iterator<EmbedFactory> factoryIterator = factoryServiceLoader.iterator();
-        if (factoryIterator.hasNext()) {
-            baseFactory = factoryIterator.next();
-            if (factoryIterator.hasNext()) {
-                throw new IllegalStateException("Found more than one EmbedFactory implementation!");
-            }
-        } else {
-            throw new IllegalStateException("No EmbedFactory implementation was found!");
-        }
-    }
-
-    /**
      * The embed factory used by this instance.
      */
-    private final EmbedFactory factory;
-
-    /**
-     * Creates a new embed builder.
-     */
-    public EmbedBuilder() {
-        factory = baseFactory.getNewInstance();
-    }
+    private final EmbedFactory factory = FactoryBuilder.createEmbedFactory();
 
     /**
      * Gets the factory used by this embed builder internally.

--- a/src/main/java/org/javacord/entity/message/embed/EmbedFactory.java
+++ b/src/main/java/org/javacord/entity/message/embed/EmbedFactory.java
@@ -17,14 +17,6 @@ import java.time.Instant;
 public interface EmbedFactory {
 
     /**
-     * Gets a new instance of an embed factory.
-     * This method is the same as calling the constructor of the implementation.
-     *
-     * @return A new instance of an embed factory.
-     */
-    EmbedFactory getNewInstance();
-
-    /**
      * Sets the title of the embed.
      *
      * @param title The title of the embed.

--- a/src/main/java/org/javacord/entity/message/embed/impl/ImplEmbedFactory.java
+++ b/src/main/java/org/javacord/entity/message/embed/impl/ImplEmbedFactory.java
@@ -63,11 +63,6 @@ public class ImplEmbedFactory implements EmbedFactory {
     }
 
     @Override
-    public ImplEmbedFactory getNewInstance() {
-        return new ImplEmbedFactory();
-    }
-
-    @Override
     public void setTitle(String title) {
         this.title = title;
     }

--- a/src/main/java/org/javacord/entity/message/impl/ImplMessageFactory.java
+++ b/src/main/java/org/javacord/entity/message/impl/ImplMessageFactory.java
@@ -72,11 +72,6 @@ public class ImplMessageFactory implements MessageFactory {
     public ImplMessageFactory() { }
 
     @Override
-    public ImplMessageFactory getNewInstance() {
-        return new ImplMessageFactory();
-    }
-
-    @Override
     public void append(String message, MessageDecoration... decorations) {
         for (MessageDecoration decoration : decorations) {
             strBuilder.append(decoration.getPrefix());

--- a/src/main/java/org/javacord/util/FactoryBuilder.java
+++ b/src/main/java/org/javacord/util/FactoryBuilder.java
@@ -1,0 +1,66 @@
+package org.javacord.util;
+
+import org.javacord.DiscordApiFactory;
+import org.javacord.entity.message.MessageFactory;
+import org.javacord.entity.message.embed.EmbedFactory;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+/**
+ * This class is used by Javacord internally.
+ * You probably won't need it ever.
+ */
+public class FactoryBuilder {
+
+    /**
+     * The factory builder delegate. It's used to create new factories.
+     */
+    private static final FactoryBuilderDelegate factoryBuilderDelegate;
+
+    // Load it static, because it has a better performance to load it only once
+    static {
+        ServiceLoader<FactoryBuilderDelegate> delegateServiceLoader = ServiceLoader.load(FactoryBuilderDelegate.class);
+        Iterator<FactoryBuilderDelegate> delegateIterator = delegateServiceLoader.iterator();
+        if (delegateIterator.hasNext()) {
+            factoryBuilderDelegate = delegateIterator.next();
+            if (delegateIterator.hasNext()) {
+                throw new IllegalStateException("Found more than one FactoryBuilderDelegate implementation!");
+            }
+        } else {
+            throw new IllegalStateException("No FactoryBuilderDelegate implementation was found!");
+        }
+    }
+
+    private FactoryBuilder() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a new discord api factory.
+     *
+     * @return A new discord api factory.
+     */
+    public static DiscordApiFactory createDiscordApiFactory() {
+        return factoryBuilderDelegate.createDiscordApiFactory();
+    }
+
+    /**
+     * Creates a new embed factory.
+     *
+     * @return A new embed factory.
+     */
+    public static EmbedFactory createEmbedFactory() {
+        return factoryBuilderDelegate.createEmbedFactory();
+    }
+
+    /**
+     * Creates a new message factory.
+     *
+     * @return A new message factory.
+     */
+    public static MessageFactory createMessageFactory() {
+        return factoryBuilderDelegate.createMessageFactory();
+    }
+
+}

--- a/src/main/java/org/javacord/util/FactoryBuilderDelegate.java
+++ b/src/main/java/org/javacord/util/FactoryBuilderDelegate.java
@@ -1,0 +1,34 @@
+package org.javacord.util;
+
+import org.javacord.DiscordApiFactory;
+import org.javacord.entity.message.MessageFactory;
+import org.javacord.entity.message.embed.EmbedFactory;
+
+/**
+ * This class is used by Javacord internally.
+ * You probably won't need it ever.
+ */
+public interface FactoryBuilderDelegate {
+
+    /**
+     * Creates a new discord api factory.
+     *
+     * @return A new discord api factory.
+     */
+    DiscordApiFactory createDiscordApiFactory();
+
+    /**
+     * Creates a new embed factory.
+     *
+     * @return A new embed factory.
+     */
+    EmbedFactory createEmbedFactory();
+
+    /**
+     * Creates a new message factory.
+     *
+     * @return A new message factory.
+     */
+    MessageFactory createMessageFactory();
+
+}

--- a/src/main/java/org/javacord/util/ImplFactoryBuilderDelegate.java
+++ b/src/main/java/org/javacord/util/ImplFactoryBuilderDelegate.java
@@ -1,0 +1,30 @@
+package org.javacord.util;
+
+import org.javacord.DiscordApiFactory;
+import org.javacord.ImplDiscordApiFactory;
+import org.javacord.entity.message.MessageFactory;
+import org.javacord.entity.message.embed.EmbedFactory;
+import org.javacord.entity.message.embed.impl.ImplEmbedFactory;
+import org.javacord.entity.message.impl.ImplMessageFactory;
+
+/**
+ * The implementation of {@code FactoryBuilderDelegate}.
+ */
+public class ImplFactoryBuilderDelegate implements FactoryBuilderDelegate {
+
+    @Override
+    public DiscordApiFactory createDiscordApiFactory() {
+        return new ImplDiscordApiFactory();
+    }
+
+    @Override
+    public EmbedFactory createEmbedFactory() {
+        return new ImplEmbedFactory();
+    }
+
+    @Override
+    public MessageFactory createMessageFactory() {
+        return new ImplMessageFactory();
+    }
+
+}

--- a/src/main/resources/META-INF/services/org.javacord.DiscordApiFactory
+++ b/src/main/resources/META-INF/services/org.javacord.DiscordApiFactory
@@ -1,1 +1,0 @@
-org.javacord.ImplDiscordApiFactory

--- a/src/main/resources/META-INF/services/org.javacord.entity.message.MessageFactory
+++ b/src/main/resources/META-INF/services/org.javacord.entity.message.MessageFactory
@@ -1,1 +1,0 @@
-org.javacord.entity.message.impl.ImplMessageFactory

--- a/src/main/resources/META-INF/services/org.javacord.entity.message.embed.EmbedFactory
+++ b/src/main/resources/META-INF/services/org.javacord.entity.message.embed.EmbedFactory
@@ -1,1 +1,0 @@
-org.javacord.entity.message.embed.impl.ImplEmbedFactory

--- a/src/main/resources/META-INF/services/org.javacord.util.FactoryBuilderDelegate
+++ b/src/main/resources/META-INF/services/org.javacord.util.FactoryBuilderDelegate
@@ -1,0 +1,1 @@
+org.javacord.util.ImplFactoryBuilderDelegate


### PR DESCRIPTION
I think it would make sense to have the service loader logic centralized only once.
Tell me if you don't like the class naming. :-)