### PR TITLE
api split

### DIFF
--- a/src/main/java/org/javacord/DiscordApiFactory.java
+++ b/src/main/java/org/javacord/DiscordApiFactory.java
@@ -57,7 +57,7 @@ public interface DiscordApiFactory {
      *
      * @return A future to check if the action was successful.
      */
-    CompletableFuture<ImplDiscordApiFactory> setRecommendedTotalShards();
+    CompletableFuture<DiscordApiFactory> setRecommendedTotalShards();
 
     /**
      * Gets the total shards.

--- a/src/main/java/org/javacord/ImplDiscordApiFactory.java
+++ b/src/main/java/org/javacord/ImplDiscordApiFactory.java
@@ -100,8 +100,8 @@ public class ImplDiscordApiFactory implements DiscordApiFactory {
     }
 
     @Override
-    public CompletableFuture<ImplDiscordApiFactory> setRecommendedTotalShards() {
-        CompletableFuture<ImplDiscordApiFactory> future = new CompletableFuture<>();
+    public CompletableFuture<DiscordApiFactory> setRecommendedTotalShards() {
+        CompletableFuture<DiscordApiFactory> future = new CompletableFuture<>();
         if (token == null) {
             future.completeExceptionally(new IllegalArgumentException("You cannot request the recommended total shards without a token!"));
             return future;

--- a/src/main/java/org/javacord/entity/permission/PermissionsBuilder.java
+++ b/src/main/java/org/javacord/entity/permission/PermissionsBuilder.java
@@ -1,19 +1,23 @@
 package org.javacord.entity.permission;
 
-import org.javacord.entity.permission.impl.ImplPermissions;
+import org.javacord.util.FactoryBuilder;
 
 /**
  * A class to create {@link Permissions permissions} objects.
  */
 public class PermissionsBuilder {
 
-    private int allowed = 0;
-    private int denied = 0;
+    /**
+     * The permissions factory used by this instance.
+     */
+    private final PermissionsFactory factory;
 
     /**
      * Creates a new permissions builder with all types set to {@link PermissionState#NONE}.
      */
-    public PermissionsBuilder() { }
+    public PermissionsBuilder() {
+        factory = FactoryBuilder.createPermissionsFactory();
+    }
 
     /**
      * Creates a new permissions builder with the states of the given permissions object.
@@ -21,8 +25,7 @@ public class PermissionsBuilder {
      * @param permissions The permissions which should be copied.
      */
     public PermissionsBuilder(Permissions permissions) {
-        allowed = permissions.getAllowedBitmask();
-        denied = permissions.getDeniedBitmask();
+        factory = FactoryBuilder.createPermissionsFactory(permissions);
     }
 
     /**
@@ -33,20 +36,7 @@ public class PermissionsBuilder {
      * @return The current instance in order to chain call methods.
      */
     public PermissionsBuilder setState(PermissionType type, PermissionState state) {
-        switch (state) {
-            case ALLOWED:
-                allowed = type.set(allowed, true);
-                denied = type.set(denied, false);
-                break;
-            case DENIED:
-                allowed = type.set(allowed, false);
-                denied = type.set(denied, true);
-                break;
-            case NONE:
-                allowed = type.set(allowed, false);
-                denied = type.set(denied, false);
-                break;
-        }
+        factory.setState(type, state);
         return this;
     }
 
@@ -57,13 +47,7 @@ public class PermissionsBuilder {
      * @return The state of the given type.
      */
     public PermissionState getState(PermissionType type) {
-        if (type.isSet(allowed)) {
-            return PermissionState.ALLOWED;
-        }
-        if (type.isSet(denied)) {
-            return PermissionState.DENIED;
-        }
-        return PermissionState.NONE;
+        return factory.getState(type);
     }
 
     /**
@@ -72,7 +56,7 @@ public class PermissionsBuilder {
      * @return The created permissions instance.
      */
     public Permissions build() {
-        return new ImplPermissions(allowed, denied);
+        return factory.build();
     }
 
 }

--- a/src/main/java/org/javacord/entity/permission/PermissionsFactory.java
+++ b/src/main/java/org/javacord/entity/permission/PermissionsFactory.java
@@ -1,0 +1,28 @@
+package org.javacord.entity.permission;
+
+public interface PermissionsFactory {
+
+    /**
+     * Sets the new state of the given type.
+     *
+     * @param type The type to change.
+     * @param state The state to set.
+     */
+    void setState(PermissionType type, PermissionState state);
+
+    /**
+     * Gets the state of the given type.
+     *
+     * @param type The type to check.
+     * @return The state of the given type.
+     */
+    PermissionState getState(PermissionType type);
+
+    /**
+     * Creates a {@link Permissions} instance with the given values.
+     *
+     * @return The created permissions instance.
+     */
+    Permissions build();
+
+}

--- a/src/main/java/org/javacord/entity/permission/Role.java
+++ b/src/main/java/org/javacord/entity/permission/Role.java
@@ -1,6 +1,5 @@
 package org.javacord.entity.permission;
 
-import org.javacord.ImplDiscordApi;
 import org.javacord.entity.DiscordEntity;
 import org.javacord.entity.Mentionable;
 import org.javacord.entity.UpdatableFromCache;
@@ -18,11 +17,7 @@ import org.javacord.listener.server.role.RoleChangePositionListener;
 import org.javacord.listener.server.role.RoleDeleteListener;
 import org.javacord.listener.server.role.UserRoleAddListener;
 import org.javacord.listener.server.role.UserRoleRemoveListener;
-import org.javacord.util.ClassHelper;
 import org.javacord.util.event.ListenerManager;
-import org.javacord.util.rest.RestEndpoint;
-import org.javacord.util.rest.RestMethod;
-import org.javacord.util.rest.RestRequest;
 
 import java.awt.Color;
 import java.util.Collection;
@@ -30,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 /**
  * This class represents a Discord role, e.g. "moderator".
@@ -188,11 +182,7 @@ public interface Role extends DiscordEntity, Mentionable, UpdatableFromCache<Rol
      *
      * @return A future to check if the deletion was successful.
      */
-    default CompletableFuture<Void> delete() {
-        return new RestRequest<Void>(getApi(), RestMethod.DELETE, RestEndpoint.ROLE)
-                .setUrlParameters(getServer().getIdAsString(), getIdAsString())
-                .execute(result -> null);
-    }
+    CompletableFuture<Void> delete();
 
     /**
      * Gets the allowed permissions of the role.
@@ -234,19 +224,14 @@ public interface Role extends DiscordEntity, Mentionable, UpdatableFromCache<Rol
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<RoleChangeColorListener> addRoleChangeColorListener(RoleChangeColorListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                Role.class, getId(), RoleChangeColorListener.class, listener);
-    }
+    ListenerManager<RoleChangeColorListener> addRoleChangeColorListener(RoleChangeColorListener listener);
 
     /**
      * Gets a list with all registered role change color listeners.
      *
      * @return A list with all registered role change color listeners.
      */
-    default List<RoleChangeColorListener> getRoleChangeColorListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangeColorListener.class);
-    }
+    List<RoleChangeColorListener> getRoleChangeColorListeners();
 
     /**
      * Adds a listener, which listens to hoist changes of this role.
@@ -254,19 +239,14 @@ public interface Role extends DiscordEntity, Mentionable, UpdatableFromCache<Rol
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<RoleChangeHoistListener> addRoleChangeHoistListener(RoleChangeHoistListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                Role.class, getId(), RoleChangeHoistListener.class, listener);
-    }
+    ListenerManager<RoleChangeHoistListener> addRoleChangeHoistListener(RoleChangeHoistListener listener);
 
     /**
      * Gets a list with all registered role change hoist listeners.
      *
      * @return A list with all registered role change hoist listeners.
      */
-    default List<RoleChangeHoistListener> getRoleChangeHoistListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangeHoistListener.class);
-    }
+    List<RoleChangeHoistListener> getRoleChangeHoistListeners();
 
     /**
      * Adds a listener, which listens to mentionable changes of this role.
@@ -274,20 +254,15 @@ public interface Role extends DiscordEntity, Mentionable, UpdatableFromCache<Rol
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<RoleChangeMentionableListener> addRoleChangeMentionableListener(
-            RoleChangeMentionableListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                Role.class, getId(), RoleChangeMentionableListener.class, listener);
-    }
+    ListenerManager<RoleChangeMentionableListener> addRoleChangeMentionableListener(
+            RoleChangeMentionableListener listener);
 
     /**
      * Gets a list with all registered role change mentionable listeners.
      *
      * @return A list with all registered role change mentionable listeners.
      */
-    default List<RoleChangeMentionableListener> getRoleChangeMentionableListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangeMentionableListener.class);
-    }
+    List<RoleChangeMentionableListener> getRoleChangeMentionableListeners();
 
     /**
      * Adds a listener, which listens to name changes of this role.
@@ -295,19 +270,14 @@ public interface Role extends DiscordEntity, Mentionable, UpdatableFromCache<Rol
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<RoleChangeNameListener> addRoleChangeNameListener(RoleChangeNameListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                Role.class, getId(), RoleChangeNameListener.class, listener);
-    }
+    ListenerManager<RoleChangeNameListener> addRoleChangeNameListener(RoleChangeNameListener listener);
 
     /**
      * Gets a list with all registered role change name listeners.
      *
      * @return A list with all registered role change name listeners.
      */
-    default List<RoleChangeNameListener> getRoleChangeNameListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangeNameListener.class);
-    }
+    List<RoleChangeNameListener> getRoleChangeNameListeners();
 
     /**
      * Adds a listener, which listens to permission changes of this role.
@@ -315,20 +285,15 @@ public interface Role extends DiscordEntity, Mentionable, UpdatableFromCache<Rol
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<RoleChangePermissionsListener> addRoleChangePermissionsListener(
-            RoleChangePermissionsListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                Role.class, getId(), RoleChangePermissionsListener.class, listener);
-    }
+    ListenerManager<RoleChangePermissionsListener> addRoleChangePermissionsListener(
+            RoleChangePermissionsListener listener);
 
     /**
      * Gets a list with all registered role change permissions listeners.
      *
      * @return A list with all registered role change permissions listeners.
      */
-    default List<RoleChangePermissionsListener> getRoleChangePermissionsListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangePermissionsListener.class);
-    }
+    List<RoleChangePermissionsListener> getRoleChangePermissionsListeners();
 
     /**
      * Adds a listener, which listens to position changes of this role.
@@ -336,20 +301,14 @@ public interface Role extends DiscordEntity, Mentionable, UpdatableFromCache<Rol
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<RoleChangePositionListener> addRoleChangePositionListener(
-            RoleChangePositionListener listener) {
-        return ((ImplDiscordApi) getApi())
-                .addObjectListener(Role.class, getId(), RoleChangePositionListener.class, listener);
-    }
+    ListenerManager<RoleChangePositionListener> addRoleChangePositionListener(RoleChangePositionListener listener);
 
     /**
      * Gets a list with all registered role change position listeners.
      *
      * @return A list with all registered role change position listeners.
      */
-    default java.util.List<RoleChangePositionListener> getRoleChangePositionListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangePositionListener.class);
-    }
+    java.util.List<RoleChangePositionListener> getRoleChangePositionListeners();
 
     /**
      * Adds a listener, which listens to overwritten permission changes of this role.
@@ -357,22 +316,16 @@ public interface Role extends DiscordEntity, Mentionable, UpdatableFromCache<Rol
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<ServerChannelChangeOverwrittenPermissionsListener>
-    addServerChannelChangeOverwrittenPermissionsListener(ServerChannelChangeOverwrittenPermissionsListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(
-                Role.class, getId(), ServerChannelChangeOverwrittenPermissionsListener.class, listener);
-    }
+    ListenerManager<ServerChannelChangeOverwrittenPermissionsListener>
+    addServerChannelChangeOverwrittenPermissionsListener(ServerChannelChangeOverwrittenPermissionsListener listener);
 
     /**
      * Gets a list with all registered server channel change overwritten permissions listeners.
      *
      * @return A list with all registered server channel change overwritten permissions listeners.
      */
-    default java.util.List<ServerChannelChangeOverwrittenPermissionsListener>
-            getServerChannelChangeOverwrittenPermissionsListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(
-                Role.class, getId(), ServerChannelChangeOverwrittenPermissionsListener.class);
-    }
+    java.util.List<ServerChannelChangeOverwrittenPermissionsListener>
+    getServerChannelChangeOverwrittenPermissionsListeners();
 
     /**
      * Adds a listener, which listens to this role being deleted.
@@ -380,19 +333,14 @@ public interface Role extends DiscordEntity, Mentionable, UpdatableFromCache<Rol
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<RoleDeleteListener> addRoleDeleteListener(RoleDeleteListener listener) {
-        return ((ImplDiscordApi) getApi())
-                .addObjectListener(Role.class, getId(), RoleDeleteListener.class, listener);
-    }
+    ListenerManager<RoleDeleteListener> addRoleDeleteListener(RoleDeleteListener listener);
 
     /**
      * Gets a list with all registered role delete listeners.
      *
      * @return A list with all registered role delete listeners.
      */
-    default java.util.List<RoleDeleteListener> getRoleDeleteListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleDeleteListener.class);
-    }
+    java.util.List<RoleDeleteListener> getRoleDeleteListeners();
 
     /**
      * Adds a listener, which listens to this user being added to this role.
@@ -400,18 +348,14 @@ public interface Role extends DiscordEntity, Mentionable, UpdatableFromCache<Rol
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<UserRoleAddListener> addUserRoleAddListener(UserRoleAddListener listener) {
-        return ((ImplDiscordApi) getApi()).addObjectListener(Role.class, getId(), UserRoleAddListener.class, listener);
-    }
+    ListenerManager<UserRoleAddListener> addUserRoleAddListener(UserRoleAddListener listener);
 
     /**
      * Gets a list with all registered user role add listeners.
      *
      * @return A list with all registered user role add listeners.
      */
-    default java.util.List<UserRoleAddListener> getUserRoleAddListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), UserRoleAddListener.class);
-    }
+    java.util.List<UserRoleAddListener> getUserRoleAddListeners();
 
     /**
      * Adds a listener, which listens to this user being removed from this role.
@@ -419,19 +363,14 @@ public interface Role extends DiscordEntity, Mentionable, UpdatableFromCache<Rol
      * @param listener The listener to add.
      * @return The manager of the listener.
      */
-    default ListenerManager<UserRoleRemoveListener> addUserRoleRemoveListener(UserRoleRemoveListener listener) {
-        return ((ImplDiscordApi) getApi())
-                .addObjectListener(Role.class, getId(), UserRoleRemoveListener.class, listener);
-    }
+    ListenerManager<UserRoleRemoveListener> addUserRoleRemoveListener(UserRoleRemoveListener listener);
 
     /**
      * Gets a list with all registered user role remove listeners.
      *
      * @return A list with all registered user role remove listeners.
      */
-    default java.util.List<UserRoleRemoveListener> getUserRoleRemoveListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), UserRoleRemoveListener.class);
-    }
+    java.util.List<UserRoleRemoveListener> getUserRoleRemoveListeners();
 
     /**
      * Adds a listener that implements one or more {@code RoleAttachableListener}s.
@@ -443,17 +382,8 @@ public interface Role extends DiscordEntity, Mentionable, UpdatableFromCache<Rol
      * @param <T> The type of the listener.
      * @return The managers for the added listener.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends RoleAttachableListener & ObjectAttachableListener> Collection<ListenerManager<T>>
-    addRoleAttachableListener(T listener) {
-        return ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(RoleAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .map(listenerClass -> ((ImplDiscordApi) getApi()).addObjectListener(Role.class, getId(),
-                                                                                    listenerClass, listener))
-                .collect(Collectors.toList());
-    }
+    <T extends RoleAttachableListener & ObjectAttachableListener> Collection<ListenerManager<T>>
+    addRoleAttachableListener(T listener);
 
     /**
      * Removes a listener that implements one or more {@code RoleAttachableListener}s.
@@ -461,16 +391,7 @@ public interface Role extends DiscordEntity, Mentionable, UpdatableFromCache<Rol
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    @SuppressWarnings("unchecked")
-    default <T extends RoleAttachableListener & ObjectAttachableListener> void removeRoleAttachableListener(
-            T listener) {
-        ClassHelper.getInterfacesAsStream(listener.getClass())
-                .filter(RoleAttachableListener.class::isAssignableFrom)
-                .filter(ObjectAttachableListener.class::isAssignableFrom)
-                .map(listenerClass -> (Class<T>) listenerClass)
-                .forEach(listenerClass -> ((ImplDiscordApi) getApi()).removeObjectListener(Role.class, getId(),
-                                                                                           listenerClass, listener));
-    }
+    <T extends RoleAttachableListener & ObjectAttachableListener> void removeRoleAttachableListener(T listener);
 
     /**
      * Gets a map with all registered listeners that implement one or more {@code RoleAttachableListener}s and their
@@ -480,10 +401,7 @@ public interface Role extends DiscordEntity, Mentionable, UpdatableFromCache<Rol
      * @return A map with all registered listeners that implement one or more {@code RoleAttachableListener}s and their
      * assigned listener classes they listen to.
      */
-    default <T extends RoleAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
-    getRoleAttachableListeners() {
-        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId());
-    }
+    <T extends RoleAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>> getRoleAttachableListeners();
 
     /**
      * Removes a listener from this role.
@@ -492,10 +410,8 @@ public interface Role extends DiscordEntity, Mentionable, UpdatableFromCache<Rol
      * @param listener The listener to remove.
      * @param <T> The type of the listener.
      */
-    default <T extends RoleAttachableListener & ObjectAttachableListener> void removeListener(
-            Class<T> listenerClass, T listener) {
-        ((ImplDiscordApi) getApi()).removeObjectListener(Role.class, getId(), listenerClass, listener);
-    }
+    <T extends RoleAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener);
 
     @Override
     default Optional<Role> getCurrentCachedInstance() {

--- a/src/main/java/org/javacord/entity/permission/RoleUpdater.java
+++ b/src/main/java/org/javacord/entity/permission/RoleUpdater.java
@@ -1,63 +1,12 @@
 package org.javacord.entity.permission;
 
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.javacord.entity.permission.impl.ImplPermissions;
-import org.javacord.util.rest.RestEndpoint;
-import org.javacord.util.rest.RestMethod;
-import org.javacord.util.rest.RestRequest;
-
 import java.awt.Color;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * This class can be used to update the settings of a role.
+ * This interface can be used to update the settings of a role.
  */
-public class RoleUpdater {
-
-    /**
-     * The role to update.
-     */
-    private final Role role;
-
-    /**
-     * The reason for the update.
-     */
-    private String reason = null;
-
-    /**
-     * The name to update.
-     */
-    private String name = null;
-
-    /**
-     * The permissions to update.
-     */
-    private Permissions permissions = null;
-
-    /**
-     * The color to update.
-     */
-    private Color color = null;
-
-    /**
-     * The display separately flag to update.
-     */
-    private Boolean displaySeparately = null;
-
-    /**
-     * The mentionable flag to update.
-     */
-    private Boolean mentionable = null;
-
-    /**
-     * Creates a new role updater.
-     *
-     * @param role The role to update.
-     */
-    public RoleUpdater(Role role) {
-        this.role = role;
-    }
+public interface RoleUpdater {
 
     /**
      * Sets the reason for this update. This reason will be visible in the audit log entry(s).
@@ -65,10 +14,7 @@ public class RoleUpdater {
      * @param reason The reason for this update.
      * @return The current instance in order to chain call methods.
      */
-    public RoleUpdater setAuditLogReason(String reason) {
-        this.reason = reason;
-        return this;
-    }
+    RoleUpdater setAuditLogReason(String reason);
 
     /**
      * Queues the name to be updated.
@@ -76,10 +22,7 @@ public class RoleUpdater {
      * @param name The new name of the role.
      * @return The current instance in order to chain call methods.
      */
-    public RoleUpdater setName(String name) {
-        this.name = name;
-        return this;
-    }
+    RoleUpdater setName(String name);
 
     /**
      * Queues the permissions to be updated.
@@ -87,10 +30,7 @@ public class RoleUpdater {
      * @param permissions The new permissions of the role.
      * @return The current instance in order to chain call methods.
      */
-    public RoleUpdater setPermissions(Permissions permissions) {
-        this.permissions = permissions;
-        return this;
-    }
+    RoleUpdater setPermissions(Permissions permissions);
 
     /**
      * Queues the color to be updated.
@@ -98,10 +38,7 @@ public class RoleUpdater {
      * @param color The new color of the role.
      * @return The current instance in order to chain call methods.
      */
-    public RoleUpdater setColor(Color color) {
-        this.color = color;
-        return this;
-    }
+    RoleUpdater setColor(Color color);
 
     /**
      * Queues the display separately flag (sometimes called "hoist") to be updated.
@@ -109,10 +46,7 @@ public class RoleUpdater {
      * @param displaySeparately The new display separately flag of the role.
      * @return The current instance in order to chain call methods.
      */
-    public RoleUpdater setDisplaySeparatelyFlag(boolean displaySeparately) {
-        this.displaySeparately = displaySeparately;
-        return this;
-    }
+    RoleUpdater setDisplaySeparatelyFlag(boolean displaySeparately);
 
     /**
      * Queues the mentionable flag to be updated.
@@ -120,48 +54,13 @@ public class RoleUpdater {
      * @param mentionable The new mentionable flag of the role.
      * @return The current instance in order to chain call methods.
      */
-    public RoleUpdater setMentionableFlag(boolean mentionable) {
-        this.mentionable = mentionable;
-        return this;
-    }
+    RoleUpdater setMentionableFlag(boolean mentionable);
 
     /**
      * Performs the queued updates.
      *
      * @return A future to check if the update was successful.
      */
-    public CompletableFuture<Void> update() {
-        boolean patchRole = false;
-        ObjectNode body = JsonNodeFactory.instance.objectNode();
-        if (name != null) {
-            body.put("name", name);
-            patchRole = true;
-        }
-        if (permissions != null) {
-            body.put("permissions", permissions.getAllowedBitmask());
-            patchRole = true;
-        }
-        if (color != null) {
-            body.put("color", color.getRGB() & 0xFFFFFF);
-            patchRole = true;
-        }
-        if (displaySeparately != null) {
-            body.put("hoist", displaySeparately.booleanValue());
-            patchRole = true;
-        }
-        if (mentionable != null) {
-            body.put("mentionable", mentionable.booleanValue());
-            patchRole = true;
-        }
-        if (patchRole) {
-            return new RestRequest<Void>(role.getApi(), RestMethod.PATCH, RestEndpoint.ROLE)
-                    .setUrlParameters(role.getServer().getIdAsString(), role.getIdAsString())
-                    .setBody(body)
-                    .setAuditLogReason(reason)
-                    .execute(result -> null);
-        } else {
-            return CompletableFuture.completedFuture(null);
-        }
-    }
+    CompletableFuture<Void> update();
 
 }

--- a/src/main/java/org/javacord/entity/permission/impl/ImplPermissionsFactory.java
+++ b/src/main/java/org/javacord/entity/permission/impl/ImplPermissionsFactory.java
@@ -1,0 +1,72 @@
+package org.javacord.entity.permission.impl;
+
+import org.javacord.entity.permission.PermissionState;
+import org.javacord.entity.permission.PermissionType;
+import org.javacord.entity.permission.Permissions;
+import org.javacord.entity.permission.PermissionsFactory;
+
+/**
+ * The implementation of {@link PermissionsFactory}.
+ */
+public class ImplPermissionsFactory implements PermissionsFactory {
+
+    /**
+     * The integer containing all allowed permission types
+     */
+    private int allowed = 0;
+
+    /**
+     * The integer containing all denied permission types.
+     */
+    private int denied = 0;
+
+    /**
+     * Creates a new permissions factory.
+     */
+    public ImplPermissionsFactory() { }
+
+    /**
+     * Creates a new permissions factory with the states of the given permissions object.
+     *
+     * @param permissions The permissions which should be copied.
+     */
+    public ImplPermissionsFactory(Permissions permissions) {
+        allowed = permissions.getAllowedBitmask();
+        denied = permissions.getDeniedBitmask();
+    }
+
+    @Override
+    public void setState(PermissionType type, PermissionState state) {
+        switch (state) {
+            case ALLOWED:
+                allowed = type.set(allowed, true);
+                denied = type.set(denied, false);
+                break;
+            case DENIED:
+                allowed = type.set(allowed, false);
+                denied = type.set(denied, true);
+                break;
+            case NONE:
+                allowed = type.set(allowed, false);
+                denied = type.set(denied, false);
+                break;
+        }
+    }
+
+    @Override
+    public PermissionState getState(PermissionType type) {
+        if (type.isSet(allowed)) {
+            return PermissionState.ALLOWED;
+        }
+        if (type.isSet(denied)) {
+            return PermissionState.DENIED;
+        }
+        return PermissionState.NONE;
+    }
+
+    @Override
+    public Permissions build() {
+        return new ImplPermissions(allowed, denied);
+    }
+
+}

--- a/src/main/java/org/javacord/entity/permission/impl/ImplRole.java
+++ b/src/main/java/org/javacord/entity/permission/impl/ImplRole.java
@@ -9,13 +9,34 @@ import org.javacord.entity.permission.Role;
 import org.javacord.entity.server.Server;
 import org.javacord.entity.server.impl.ImplServer;
 import org.javacord.entity.user.User;
+import org.javacord.listener.ObjectAttachableListener;
+import org.javacord.listener.channel.server.ServerChannelChangeOverwrittenPermissionsListener;
+import org.javacord.listener.server.role.RoleAttachableListener;
+import org.javacord.listener.server.role.RoleChangeColorListener;
+import org.javacord.listener.server.role.RoleChangeHoistListener;
+import org.javacord.listener.server.role.RoleChangeMentionableListener;
+import org.javacord.listener.server.role.RoleChangeNameListener;
+import org.javacord.listener.server.role.RoleChangePermissionsListener;
+import org.javacord.listener.server.role.RoleChangePositionListener;
+import org.javacord.listener.server.role.RoleDeleteListener;
+import org.javacord.listener.server.role.UserRoleAddListener;
+import org.javacord.listener.server.role.UserRoleRemoveListener;
+import org.javacord.util.ClassHelper;
+import org.javacord.util.event.ListenerManager;
+import org.javacord.util.rest.RestEndpoint;
+import org.javacord.util.rest.RestMethod;
+import org.javacord.util.rest.RestRequest;
 
 import java.awt.Color;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 /**
  * The implementation of {@link Role}.
@@ -243,6 +264,164 @@ public class ImplRole implements Role {
     @Override
     public boolean isManaged() {
         return managed;
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+        return new RestRequest<Void>(getApi(), RestMethod.DELETE, RestEndpoint.ROLE)
+                .setUrlParameters(getServer().getIdAsString(), getIdAsString())
+                .execute(result -> null);
+    }
+
+    @Override
+    public ListenerManager<RoleChangeColorListener> addRoleChangeColorListener(RoleChangeColorListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                Role.class, getId(), RoleChangeColorListener.class, listener);
+    }
+
+    @Override
+    public List<RoleChangeColorListener> getRoleChangeColorListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangeColorListener.class);
+    }
+
+    @Override
+    public ListenerManager<RoleChangeHoistListener> addRoleChangeHoistListener(RoleChangeHoistListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                Role.class, getId(), RoleChangeHoistListener.class, listener);
+    }
+
+    @Override
+    public List<RoleChangeHoistListener> getRoleChangeHoistListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangeHoistListener.class);
+    }
+
+    @Override
+    public ListenerManager<RoleChangeMentionableListener> addRoleChangeMentionableListener(
+            RoleChangeMentionableListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                Role.class, getId(), RoleChangeMentionableListener.class, listener);
+    }
+
+    @Override
+    public List<RoleChangeMentionableListener> getRoleChangeMentionableListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangeMentionableListener.class);
+    }
+
+    @Override
+    public ListenerManager<RoleChangeNameListener> addRoleChangeNameListener(RoleChangeNameListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                Role.class, getId(), RoleChangeNameListener.class, listener);
+    }
+
+    @Override
+    public List<RoleChangeNameListener> getRoleChangeNameListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangeNameListener.class);
+    }
+
+    @Override
+    public ListenerManager<RoleChangePermissionsListener> addRoleChangePermissionsListener(
+            RoleChangePermissionsListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                Role.class, getId(), RoleChangePermissionsListener.class, listener);
+    }
+
+    @Override
+    public List<RoleChangePermissionsListener> getRoleChangePermissionsListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangePermissionsListener.class);
+    }
+
+    @Override
+    public ListenerManager<RoleChangePositionListener> addRoleChangePositionListener(
+            RoleChangePositionListener listener) {
+        return ((ImplDiscordApi) getApi())
+                .addObjectListener(Role.class, getId(), RoleChangePositionListener.class, listener);
+    }
+
+    @Override
+    public java.util.List<RoleChangePositionListener> getRoleChangePositionListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleChangePositionListener.class);
+    }
+
+    @Override
+    public ListenerManager<ServerChannelChangeOverwrittenPermissionsListener>
+    addServerChannelChangeOverwrittenPermissionsListener(ServerChannelChangeOverwrittenPermissionsListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(
+                Role.class, getId(), ServerChannelChangeOverwrittenPermissionsListener.class, listener);
+    }
+
+    @Override
+    public java.util.List<ServerChannelChangeOverwrittenPermissionsListener>
+            getServerChannelChangeOverwrittenPermissionsListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(
+                Role.class, getId(), ServerChannelChangeOverwrittenPermissionsListener.class);
+    }
+
+    @Override
+    public ListenerManager<RoleDeleteListener> addRoleDeleteListener(RoleDeleteListener listener) {
+        return ((ImplDiscordApi) getApi())
+                .addObjectListener(Role.class, getId(), RoleDeleteListener.class, listener);
+    }
+
+    @Override
+    public java.util.List<RoleDeleteListener> getRoleDeleteListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), RoleDeleteListener.class);
+    }
+
+    @Override
+    public ListenerManager<UserRoleAddListener> addUserRoleAddListener(UserRoleAddListener listener) {
+        return ((ImplDiscordApi) getApi()).addObjectListener(Role.class, getId(), UserRoleAddListener.class, listener);
+    }
+
+    @Override
+    public java.util.List<UserRoleAddListener> getUserRoleAddListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), UserRoleAddListener.class);
+    }
+
+    @Override
+    public ListenerManager<UserRoleRemoveListener> addUserRoleRemoveListener(UserRoleRemoveListener listener) {
+        return ((ImplDiscordApi) getApi())
+                .addObjectListener(Role.class, getId(), UserRoleRemoveListener.class, listener);
+    }
+
+    @Override
+    public java.util.List<UserRoleRemoveListener> getUserRoleRemoveListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId(), UserRoleRemoveListener.class);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends RoleAttachableListener & ObjectAttachableListener> Collection<ListenerManager<T>>
+    addRoleAttachableListener(T listener) {
+        return ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(RoleAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .map(listenerClass -> ((ImplDiscordApi) getApi()).addObjectListener(Role.class, getId(),
+                                                                                    listenerClass, listener))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends RoleAttachableListener & ObjectAttachableListener> void removeRoleAttachableListener(T listener) {
+        ClassHelper.getInterfacesAsStream(listener.getClass())
+                .filter(RoleAttachableListener.class::isAssignableFrom)
+                .filter(ObjectAttachableListener.class::isAssignableFrom)
+                .map(listenerClass -> (Class<T>) listenerClass)
+                .forEach(listenerClass -> ((ImplDiscordApi) getApi()).removeObjectListener(Role.class, getId(),
+                                                                                           listenerClass, listener));
+    }
+
+    @Override
+    public <T extends RoleAttachableListener & ObjectAttachableListener> Map<T, List<Class<T>>>
+    getRoleAttachableListeners() {
+        return ((ImplDiscordApi) getApi()).getObjectListeners(Role.class, getId());
+    }
+
+    @Override
+    public <T extends RoleAttachableListener & ObjectAttachableListener> void removeListener(
+            Class<T> listenerClass, T listener) {
+        ((ImplDiscordApi) getApi()).removeObjectListener(Role.class, getId(), listenerClass, listener);
     }
 
     @Override

--- a/src/main/java/org/javacord/entity/permission/impl/ImplRoleUpdater.java
+++ b/src/main/java/org/javacord/entity/permission/impl/ImplRoleUpdater.java
@@ -1,0 +1,135 @@
+package org.javacord.entity.permission.impl;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.javacord.entity.permission.Permissions;
+import org.javacord.entity.permission.Role;
+import org.javacord.entity.permission.RoleUpdater;
+import org.javacord.util.rest.RestEndpoint;
+import org.javacord.util.rest.RestMethod;
+import org.javacord.util.rest.RestRequest;
+
+import java.awt.Color;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This class can be used to update the settings of a role.
+ */
+public class ImplRoleUpdater implements RoleUpdater {
+
+    /**
+     * The role to update.
+     */
+    private final Role role;
+
+    /**
+     * The reason for the update.
+     */
+    private String reason = null;
+
+    /**
+     * The name to update.
+     */
+    private String name = null;
+
+    /**
+     * The permissions to update.
+     */
+    private Permissions permissions = null;
+
+    /**
+     * The color to update.
+     */
+    private Color color = null;
+
+    /**
+     * The display separately flag to update.
+     */
+    private Boolean displaySeparately = null;
+
+    /**
+     * The mentionable flag to update.
+     */
+    private Boolean mentionable = null;
+
+    /**
+     * Creates a new role updater.
+     *
+     * @param role The role to update.
+     */
+    public ImplRoleUpdater(Role role) {
+        this.role = role;
+    }
+
+    @Override
+    public RoleUpdater setAuditLogReason(String reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    @Override
+    public RoleUpdater setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    public RoleUpdater setPermissions(Permissions permissions) {
+        this.permissions = permissions;
+        return this;
+    }
+
+    @Override
+    public RoleUpdater setColor(Color color) {
+        this.color = color;
+        return this;
+    }
+
+    @Override
+    public RoleUpdater setDisplaySeparatelyFlag(boolean displaySeparately) {
+        this.displaySeparately = displaySeparately;
+        return this;
+    }
+
+    @Override
+    public RoleUpdater setMentionableFlag(boolean mentionable) {
+        this.mentionable = mentionable;
+        return this;
+    }
+
+    @Override
+    public CompletableFuture<Void> update() {
+        boolean patchRole = false;
+        ObjectNode body = JsonNodeFactory.instance.objectNode();
+        if (name != null) {
+            body.put("name", name);
+            patchRole = true;
+        }
+        if (permissions != null) {
+            body.put("permissions", permissions.getAllowedBitmask());
+            patchRole = true;
+        }
+        if (color != null) {
+            body.put("color", color.getRGB() & 0xFFFFFF);
+            patchRole = true;
+        }
+        if (displaySeparately != null) {
+            body.put("hoist", displaySeparately.booleanValue());
+            patchRole = true;
+        }
+        if (mentionable != null) {
+            body.put("mentionable", mentionable.booleanValue());
+            patchRole = true;
+        }
+        if (patchRole) {
+            return new RestRequest<Void>(role.getApi(), RestMethod.PATCH, RestEndpoint.ROLE)
+                    .setUrlParameters(role.getServer().getIdAsString(), role.getIdAsString())
+                    .setBody(body)
+                    .setAuditLogReason(reason)
+                    .execute(result -> null);
+        } else {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+}

--- a/src/main/java/org/javacord/util/FactoryBuilder.java
+++ b/src/main/java/org/javacord/util/FactoryBuilder.java
@@ -3,6 +3,8 @@ package org.javacord.util;
 import org.javacord.DiscordApiFactory;
 import org.javacord.entity.message.MessageFactory;
 import org.javacord.entity.message.embed.EmbedFactory;
+import org.javacord.entity.permission.Permissions;
+import org.javacord.entity.permission.PermissionsFactory;
 
 import java.util.Iterator;
 import java.util.ServiceLoader;
@@ -61,6 +63,25 @@ public class FactoryBuilder {
      */
     public static MessageFactory createMessageFactory() {
         return factoryBuilderDelegate.createMessageFactory();
+    }
+
+    /**
+     * Creates a new permissions factory.
+     *
+     * @return A new permissions factory.
+     */
+    public static PermissionsFactory createPermissionsFactory() {
+        return factoryBuilderDelegate.createPermissionsFactory();
+    }
+
+    /**
+     * Creates a new permissions factory initialized with the given permissions.
+     *
+     * @param permissions The permissions which should be copied.
+     * @return A new permissions factory initialized with the given permissions.
+     */
+    public static PermissionsFactory createPermissionsFactory(Permissions permissions) {
+        return factoryBuilderDelegate.createPermissionsFactory(permissions);
     }
 
 }

--- a/src/main/java/org/javacord/util/FactoryBuilderDelegate.java
+++ b/src/main/java/org/javacord/util/FactoryBuilderDelegate.java
@@ -3,6 +3,8 @@ package org.javacord.util;
 import org.javacord.DiscordApiFactory;
 import org.javacord.entity.message.MessageFactory;
 import org.javacord.entity.message.embed.EmbedFactory;
+import org.javacord.entity.permission.Permissions;
+import org.javacord.entity.permission.PermissionsFactory;
 
 /**
  * This class is used by Javacord internally.
@@ -30,5 +32,20 @@ public interface FactoryBuilderDelegate {
      * @return A new message factory.
      */
     MessageFactory createMessageFactory();
+
+    /**
+     * Creates a new permissions factory.
+     *
+     * @return A new permissions factory.
+     */
+    PermissionsFactory createPermissionsFactory();
+
+    /**
+     * Creates a new permissions factory initialized with the given permissions.
+     *
+     * @param permissions The permissions which should be copied.
+     * @return A new permissions factory initialized with the given permissions.
+     */
+    PermissionsFactory createPermissionsFactory(Permissions permissions);
 
 }

--- a/src/main/java/org/javacord/util/ImplFactoryBuilderDelegate.java
+++ b/src/main/java/org/javacord/util/ImplFactoryBuilderDelegate.java
@@ -6,6 +6,9 @@ import org.javacord.entity.message.MessageFactory;
 import org.javacord.entity.message.embed.EmbedFactory;
 import org.javacord.entity.message.embed.impl.ImplEmbedFactory;
 import org.javacord.entity.message.impl.ImplMessageFactory;
+import org.javacord.entity.permission.Permissions;
+import org.javacord.entity.permission.PermissionsFactory;
+import org.javacord.entity.permission.impl.ImplPermissionsFactory;
 
 /**
  * The implementation of {@code FactoryBuilderDelegate}.
@@ -25,6 +28,16 @@ public class ImplFactoryBuilderDelegate implements FactoryBuilderDelegate {
     @Override
     public MessageFactory createMessageFactory() {
         return new ImplMessageFactory();
+    }
+
+    @Override
+    public PermissionsFactory createPermissionsFactory() {
+        return new ImplPermissionsFactory();
+    }
+
+    @Override
+    public PermissionsFactory createPermissionsFactory(Permissions permissions) {
+        return new ImplPermissionsFactory(permissions);
     }
 
 }


### PR DESCRIPTION
- Make PermissionsBuilder implementation-independent
- Make Role implementation-independent
- Fix return type of DiscordApiFactory#setRecommendedTotalShards
- Split RoleUpdater into implementation and interface