### PR TITLE
Fix exception validation

### DIFF
--- a/src/main/java/org/javacord/exception/DiscordException.java
+++ b/src/main/java/org/javacord/exception/DiscordException.java
@@ -1,5 +1,6 @@
 package org.javacord.exception;
 
+import org.javacord.util.FactoryBuilder;
 import org.javacord.util.rest.RestRequestInformation;
 import org.javacord.util.rest.RestRequestResponseInformation;
 
@@ -33,6 +34,8 @@ public class DiscordException extends Exception {
         super(message, origin);
         this.request = request;
         this.response = response;
+
+        FactoryBuilder.getDiscordExceptionValidator().validateException(this);
     }
 
     /**

--- a/src/main/java/org/javacord/util/FactoryBuilder.java
+++ b/src/main/java/org/javacord/util/FactoryBuilder.java
@@ -5,6 +5,7 @@ import org.javacord.entity.message.MessageFactory;
 import org.javacord.entity.message.embed.EmbedFactory;
 import org.javacord.entity.permission.Permissions;
 import org.javacord.entity.permission.PermissionsFactory;
+import org.javacord.util.exception.DiscordExceptionValidator;
 
 import java.util.Iterator;
 import java.util.ServiceLoader;
@@ -20,6 +21,11 @@ public class FactoryBuilder {
      */
     private static final FactoryBuilderDelegate factoryBuilderDelegate;
 
+    /**
+     * The discord exception validator.
+     */
+    private static final DiscordExceptionValidator discordExceptionValidator;
+
     // Load it static, because it has a better performance to load it only once
     static {
         ServiceLoader<FactoryBuilderDelegate> delegateServiceLoader = ServiceLoader.load(FactoryBuilderDelegate.class);
@@ -32,6 +38,7 @@ public class FactoryBuilder {
         } else {
             throw new IllegalStateException("No FactoryBuilderDelegate implementation was found!");
         }
+        discordExceptionValidator = factoryBuilderDelegate.createDiscordExceptionValidator();
     }
 
     private FactoryBuilder() {
@@ -82,6 +89,15 @@ public class FactoryBuilder {
      */
     public static PermissionsFactory createPermissionsFactory(Permissions permissions) {
         return factoryBuilderDelegate.createPermissionsFactory(permissions);
+    }
+
+    /**
+     * Gets the discord exception validator.
+     *
+     * @return The discord exception validator.
+     */
+    public static DiscordExceptionValidator getDiscordExceptionValidator() {
+        return discordExceptionValidator;
     }
 
 }

--- a/src/main/java/org/javacord/util/FactoryBuilderDelegate.java
+++ b/src/main/java/org/javacord/util/FactoryBuilderDelegate.java
@@ -5,6 +5,7 @@ import org.javacord.entity.message.MessageFactory;
 import org.javacord.entity.message.embed.EmbedFactory;
 import org.javacord.entity.permission.Permissions;
 import org.javacord.entity.permission.PermissionsFactory;
+import org.javacord.util.exception.DiscordExceptionValidator;
 
 /**
  * This class is used by Javacord internally.
@@ -47,5 +48,12 @@ public interface FactoryBuilderDelegate {
      * @return A new permissions factory initialized with the given permissions.
      */
     PermissionsFactory createPermissionsFactory(Permissions permissions);
+
+    /**
+     * Creates a new discord exception validator.
+     *
+     * @return A new discord exception validator.
+     */
+    DiscordExceptionValidator createDiscordExceptionValidator();
 
 }

--- a/src/main/java/org/javacord/util/ImplFactoryBuilderDelegate.java
+++ b/src/main/java/org/javacord/util/ImplFactoryBuilderDelegate.java
@@ -9,6 +9,8 @@ import org.javacord.entity.message.impl.ImplMessageFactory;
 import org.javacord.entity.permission.Permissions;
 import org.javacord.entity.permission.PermissionsFactory;
 import org.javacord.entity.permission.impl.ImplPermissionsFactory;
+import org.javacord.util.exception.DiscordExceptionValidator;
+import org.javacord.util.exception.impl.ImplDiscordExceptionValidator;
 
 /**
  * The implementation of {@code FactoryBuilderDelegate}.
@@ -38,6 +40,11 @@ public class ImplFactoryBuilderDelegate implements FactoryBuilderDelegate {
     @Override
     public PermissionsFactory createPermissionsFactory(Permissions permissions) {
         return new ImplPermissionsFactory(permissions);
+    }
+
+    @Override
+    public DiscordExceptionValidator createDiscordExceptionValidator() {
+        return new ImplDiscordExceptionValidator();
     }
 
 }

--- a/src/main/java/org/javacord/util/exception/DiscordExceptionValidator.java
+++ b/src/main/java/org/javacord/util/exception/DiscordExceptionValidator.java
@@ -1,21 +1,11 @@
 package org.javacord.util.exception;
 
-import okhttp3.Response;
 import org.javacord.exception.DiscordException;
-import org.javacord.util.rest.RestRequestHttpResponseCode;
-import org.javacord.util.rest.RestRequestResult;
-import org.javacord.util.rest.impl.ImplRestRequestResponseInformation;
-
-import java.util.Optional;
 
 /**
  * Validates if discord exceptions are from the correct type.
  */
-public class DiscordExceptionValidator {
-
-    private DiscordExceptionValidator() {
-        throw new UnsupportedOperationException();
-    }
+public interface DiscordExceptionValidator {
 
     /**
      * Validates that the exception is used for the HTTP response code it is meant for and vice versa.
@@ -23,58 +13,6 @@ public class DiscordExceptionValidator {
      * @param exception The exception to check.
      * @throws AssertionError If the exception is invalid.
      */
-    public static void validateException(DiscordException exception) throws AssertionError {
-        Optional<RestRequestHttpResponseCode> expectedResponseCodeOptional =
-                RestRequestHttpResponseCode.fromDiscordExceptionClass(exception.getClass());
-        Optional<RestRequestResult> restRequestResultOptional = exception.getResponse()
-                .map(response -> ((ImplRestRequestResponseInformation) response))
-                .map(ImplRestRequestResponseInformation::getRestRequestResult);
-
-        if (expectedResponseCodeOptional.isPresent()) {
-            // if this class or a superclass of it is the expected exception class for an HTTP response code
-            RestRequestHttpResponseCode expectedResponseCode = expectedResponseCodeOptional.get();
-            if (restRequestResultOptional.isPresent()) {
-                // if there is an actual result but the response code does not match
-                if (restRequestResultOptional.get().getResponse().code() != expectedResponseCode.getCode()) {
-                    throw new AssertionError(exception.getClass().getSimpleName()
-                            + " should only be thrown on "
-                            + expectedResponseCode.getCode()
-                            + " HTTP response code (was "
-                            + restRequestResultOptional.get().getResponse().code()
-                            + ") or it should not be a subclass of "
-                            + expectedResponseCode
-                            .getDiscordExceptionClass()
-                            .orElseThrow(AssertionError::new)
-                            .getSimpleName()
-                            + ". Please contact the developer!");
-                }
-            } else {
-                // if there is no actual result
-                throw new AssertionError(exception.getClass().getSimpleName()
-                        + " should only be thrown on "
-                        + expectedResponseCode.getCode()
-                        + " HTTP response code but there is no result. "
-                        + "Please contact the developer!");
-            }
-        } else {
-            // if this class or a superclass of it is not the expected exception class for an HTTP response code
-            Optional<Integer> responseCodeOptional = restRequestResultOptional
-                    .map(RestRequestResult::getResponse)
-                    .map(Response::code);
-            Optional<? extends Class<? extends DiscordException>> discordExceptionClassOptional =
-                    responseCodeOptional
-                            .flatMap(RestRequestHttpResponseCode::fromCode)
-                            .flatMap(RestRequestHttpResponseCode::getDiscordExceptionClass);
-            // if there is a result present and for its HTTP response code exists an expected exception
-            if (discordExceptionClassOptional.isPresent()) {
-                throw new AssertionError("For "
-                        + responseCodeOptional.orElseThrow(AssertionError::new)
-                        + " HTTP response code an exception of type "
-                        + discordExceptionClassOptional.get().getSimpleName()
-                        + " or a sub-class thereof should be thrown. "
-                        + "Please contact the developer!");
-            }
-        }
-    }
+    void validateException(DiscordException exception) throws AssertionError;
 
 }

--- a/src/main/java/org/javacord/util/exception/impl/ImplDiscordExceptionValidator.java
+++ b/src/main/java/org/javacord/util/exception/impl/ImplDiscordExceptionValidator.java
@@ -1,0 +1,67 @@
+package org.javacord.util.exception.impl;
+
+import org.javacord.exception.DiscordException;
+import org.javacord.util.exception.DiscordExceptionValidator;
+import org.javacord.util.rest.RestRequestHttpResponseCode;
+import org.javacord.util.rest.RestRequestResponseInformation;
+
+import java.util.Optional;
+
+/**
+ * Validates if discord exceptions are from the correct type.
+ */
+public class ImplDiscordExceptionValidator implements DiscordExceptionValidator {
+
+    @Override
+    public void validateException(DiscordException exception) throws AssertionError {
+        Optional<RestRequestHttpResponseCode> expectedResponseCodeOptional =
+                RestRequestHttpResponseCode.fromDiscordExceptionClass(exception.getClass());
+        Optional<RestRequestResponseInformation> restRequestResponseInformationOptional = exception.getResponse();
+
+        if (expectedResponseCodeOptional.isPresent()) {
+            // if this class or a superclass of it is the expected exception class for an HTTP response code
+            RestRequestHttpResponseCode expectedResponseCode = expectedResponseCodeOptional.get();
+            if (restRequestResponseInformationOptional.isPresent()) {
+                // if there is an actual result but the response code does not match
+                if (restRequestResponseInformationOptional.get().getCode() != expectedResponseCode.getCode()) {
+                    throw new AssertionError(exception.getClass().getSimpleName()
+                            + " should only be thrown on "
+                            + expectedResponseCode.getCode()
+                            + " HTTP response code (was "
+                            + restRequestResponseInformationOptional.get().getCode()
+                            + ") or it should not be a subclass of "
+                            + expectedResponseCode
+                            .getDiscordExceptionClass()
+                            .orElseThrow(AssertionError::new)
+                            .getSimpleName()
+                            + ". Please contact the developer!");
+                }
+            } else {
+                // if there is no actual result
+                throw new AssertionError(exception.getClass().getSimpleName()
+                        + " should only be thrown on "
+                        + expectedResponseCode.getCode()
+                        + " HTTP response code but there is no result. "
+                        + "Please contact the developer!");
+            }
+        } else {
+            // if this class or a superclass of it is not the expected exception class for an HTTP response code
+            Optional<Integer> responseCodeOptional = restRequestResponseInformationOptional
+                    .map(RestRequestResponseInformation::getCode);
+            Optional<? extends Class<? extends DiscordException>> discordExceptionClassOptional =
+                    responseCodeOptional
+                            .flatMap(RestRequestHttpResponseCode::fromCode)
+                            .flatMap(RestRequestHttpResponseCode::getDiscordExceptionClass);
+            // if there is a result present and for its HTTP response code exists an expected exception
+            if (discordExceptionClassOptional.isPresent()) {
+                throw new AssertionError("For "
+                        + responseCodeOptional.orElseThrow(AssertionError::new)
+                        + " HTTP response code an exception of type "
+                        + discordExceptionClassOptional.get().getSimpleName()
+                        + " or a sub-class thereof should be thrown. "
+                        + "Please contact the developer!");
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/javacord/util/rest/RestRequestHttpResponseCode.java
+++ b/src/main/java/org/javacord/util/rest/RestRequestHttpResponseCode.java
@@ -5,7 +5,6 @@ import org.javacord.exception.DiscordException;
 import org.javacord.exception.DiscordExceptionInstantiator;
 import org.javacord.exception.MissingPermissionsException;
 import org.javacord.exception.NotFoundException;
-import org.javacord.util.exception.DiscordExceptionValidator;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -219,10 +218,8 @@ public enum RestRequestHttpResponseCode {
     public Optional<? extends DiscordException> getDiscordException(Exception origin, String message,
                                                                     RestRequestInformation request,
                                                                     RestRequestResponseInformation response) {
-        Optional<? extends DiscordException> exception = Optional.ofNullable(discordExceptionInstantiator)
+        return Optional.ofNullable(discordExceptionInstantiator)
                 .map(instantiator -> instantiator.createInstance(origin, message, request, response));
-        exception.ifPresent(DiscordExceptionValidator::validateException);
-        return exception;
     }
 
     /**

--- a/src/main/java/org/javacord/util/rest/RestRequestResultErrorCode.java
+++ b/src/main/java/org/javacord/util/rest/RestRequestResultErrorCode.java
@@ -6,7 +6,6 @@ import org.javacord.exception.DiscordExceptionInstantiator;
 import org.javacord.exception.ReactionBlockedException;
 import org.javacord.exception.UnknownEmojiException;
 import org.javacord.exception.UnknownMessageException;
-import org.javacord.util.exception.DiscordExceptionValidator;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -162,10 +161,8 @@ public enum RestRequestResultErrorCode {
     public Optional<? extends DiscordException> getDiscordException(Exception origin, String message,
                                                                     RestRequestInformation request,
                                                                     RestRequestResponseInformation response) {
-        Optional<? extends DiscordException> exception = Optional.ofNullable(discordExceptionInstantiator)
+        return Optional.ofNullable(discordExceptionInstantiator)
                 .map(instantiator -> instantiator.createInstance(origin, message, request, response));
-        exception.ifPresent(DiscordExceptionValidator::validateException);
-        return exception;
     }
 
 }


### PR DESCRIPTION
The exception validation needs to stay in the `DiscordException` constructor, or you miss the "there is no actual result" case.
As the `FactoryBuilder` now not only delivers factories, maybe we should find a better name?
`ServiceLocator`?
`HelperLocator`?
`UtilitiesLocator`?
`UtilsLocator`?