### PR TITLE
Retry on error while initially connecting and while requesting recommended total shards count

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
+++ b/javacord-core/src/main/java/org/javacord/core/util/gateway/DiscordWebSocketAdapter.java
@@ -300,13 +300,9 @@ public class DiscordWebSocketAdapter extends WebSocketAdapter {
             websocket.connect();
         } catch (Throwable t) {
             logger.warn("An error occurred while connecting to websocket", t);
-            if (!ready.isDone()) {
-                ready.complete(false);
-                return;
-            }
             if (reconnect) {
                 reconnectAttempt++;
-                logger.info("Trying to reconnect/resume in {} seconds!", api.getReconnectDelay(reconnectAttempt));
+                logger.info("Retrying to reconnect/resume in {} seconds!", api.getReconnectDelay(reconnectAttempt));
                 // Reconnect after a (short?) delay depending on the amount of reconnect attempts
                 api.getThreadPool().getScheduler()
                         .schedule(() -> {


### PR DESCRIPTION
Error due to wrong token actually is not affected, because in that case you are already connected and get a close frame from the server before the ready future was completed, so no retry will be done as it is the `Websocket closed before READY packet was received` case.