### PR TITLE
Fix ban method ignoring the reason parameter

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/ServerImpl.java
@@ -1006,7 +1006,7 @@ public class ServerImpl implements Server, Cleanupable {
                 .setUrlParameters(getIdAsString(), user.getIdAsString())
                 .addQueryParameter("delete-message-days", String.valueOf(deleteMessageDays));
         if (reason != null) {
-            request.addHeader("reason", reason);
+            request.addQueryParameter("reason", reason);
         }
         return request.execute(result -> null);
     }


### PR DESCRIPTION
If you don't know what the bug is, basically reasons didn't get attached to bans, either in the `Bans` list or in the audit log. I'm *not* sure if the setAuditLogReason line is required, or if addQueryParameter does it too, but I've tested this fix and it works just fine 😄 