### PR TITLE
Add support for member count via invite.

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
+++ b/javacord-api/src/main/java/org/javacord/api/DiscordApi.java
@@ -392,6 +392,14 @@ public interface DiscordApi {
     CompletableFuture<Invite> getInviteByCode(String code);
 
     /**
+     * Gets an invite by its code while requesting additional information.
+     *
+     * @param code The code of the invite.
+     * @return The invite with the given code.
+     */
+    CompletableFuture<Invite> getInviteWithMemberCountsByCode(String code);
+
+    /**
      * Creates a server builder which can be used to create servers.
      *
      * @return A server builder.

--- a/javacord-api/src/main/java/org/javacord/api/entity/server/invite/Invite.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/server/invite/Invite.java
@@ -117,4 +117,18 @@ public interface Invite {
      */
     CompletableFuture<Void> delete(String reason);
 
+    /**
+     * Gets the approximate number of members for the target server.
+     *
+     * @return The count of members, if available.
+     */
+    Optional<Integer> getApproximateMemberCount();
+
+    /**
+     * Gets the approximate number of online members for the target server.
+     *
+     * @return The count of present members, if available.
+     */
+    Optional<Integer> getApproximatePresenceCount();
+
 }

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -1154,6 +1154,13 @@ public class DiscordApiImpl implements DiscordApi {
     @Override
     public CompletableFuture<Invite> getInviteByCode(String code) {
         return new RestRequest<Invite>(this, RestMethod.GET, RestEndpoint.INVITE)
+                .addQueryParameter("with_counts", "false")
+                .execute(result -> new InviteImpl(this, result.getJsonBody()));
+    }
+
+    @Override
+    public CompletableFuture<Invite> getInviteWithMemberCountsByCode(String code) {
+        return new RestRequest<Invite>(this, RestMethod.GET, RestEndpoint.INVITE)
                 .setUrlParameters(code)
                 .addQueryParameter("with_counts", "true")
                 .execute(result -> new InviteImpl(this, result.getJsonBody()));

--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -1155,6 +1155,7 @@ public class DiscordApiImpl implements DiscordApi {
     public CompletableFuture<Invite> getInviteByCode(String code) {
         return new RestRequest<Invite>(this, RestMethod.GET, RestEndpoint.INVITE)
                 .setUrlParameters(code)
+                .addQueryParameter("with_counts", "true")
                 .execute(result -> new InviteImpl(this, result.getJsonBody()));
     }
 

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/invite/InviteImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/invite/InviteImpl.java
@@ -115,6 +115,16 @@ public class InviteImpl implements RichInvite {
     private final boolean revoked;
 
     /**
+     * The approximate count of members, if available
+     */
+    private final Integer approximateMemberCount;
+
+    /**
+     * The approximate count of present members, if available
+     */
+    private final Integer approximatePresenceCount;
+
+    /**
      * Creates a new invite.
      *
      * @param api The discord api instance.
@@ -134,6 +144,14 @@ public class InviteImpl implements RichInvite {
         this.channelId = Long.parseLong(data.get("channel").get("id").asText());
         this.channelName = data.get("channel").get("name").asText();
         this.channelType = ChannelType.fromId(data.get("channel").get("type").asInt());
+
+        // May not be present / only present if requested
+        this.approximateMemberCount = (data.has("approximate_member_count"))
+                ? data.get("approximate_member_count").asInt()
+                : null;
+        this.approximatePresenceCount = (data.has("approximate_presence_count"))
+                ? data.get("approximate_presence_count").asInt()
+                : null;
 
         // Rich data (may not be present)
         this.inviter = data.has("inviter")
@@ -269,5 +287,15 @@ public class InviteImpl implements RichInvite {
     @Override
     public boolean isRevoked() {
         return revoked;
+    }
+
+    @Override
+    public Optional<Integer> getApproximateMemberCount() {
+        return Optional.ofNullable(approximateMemberCount);
+    }
+
+    @Override
+    public Optional<Integer> getApproximatePresenceCount() {
+        return Optional.ofNullable(approximatePresenceCount);
     }
 }

--- a/javacord-core/src/main/java/org/javacord/core/entity/server/invite/InviteImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/entity/server/invite/InviteImpl.java
@@ -115,12 +115,12 @@ public class InviteImpl implements RichInvite {
     private final boolean revoked;
 
     /**
-     * The approximate count of members, if available
+     * The approximate count of members, if available.
      */
     private final Integer approximateMemberCount;
 
     /**
-     * The approximate count of present members, if available
+     * The approximate count of present members, if available.
      */
     private final Integer approximatePresenceCount;
 


### PR DESCRIPTION
Quick stab at an item from the ToDo List.

Currently this change will always request counts when grabbing an invite.