### PR TITLE
Simplify asXyz methods

### DIFF
--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/Categorizable.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/Categorizable.java
@@ -1,12 +1,14 @@
 package org.javacord.api.entity.channel;
 
+import org.javacord.api.entity.channel.internal.ChannelBase;
+
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
  * This class represents an entity which can have a channel category.
  */
-public interface Categorizable {
+public interface Categorizable extends ChannelBase {
 
     /**
      * Gets the category of the channel.

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/Channel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/Channel.java
@@ -7,7 +7,7 @@ import org.javacord.api.entity.permission.PermissionType;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.listener.ChannelAttachableListener;
 import org.javacord.api.listener.ObjectAttachableListener;
-import org.javacord.api.util.Specializable;
+import org.javacord.api.util.Specifiable;
 import org.javacord.api.util.event.ListenerManager;
 
 import java.util.Collection;
@@ -20,7 +20,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * The class represents a channel.
  */
-public interface Channel extends DiscordEntity, UpdatableFromCache, ChannelBase, Specializable<ChannelBase> {
+public interface Channel extends DiscordEntity, UpdatableFromCache, ChannelBase, Specifiable<ChannelBase> {
 
     /**
      * Gets the type of the channel.

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/Channel.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/Channel.java
@@ -2,10 +2,12 @@ package org.javacord.api.entity.channel;
 
 import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.entity.UpdatableFromCache;
+import org.javacord.api.entity.channel.internal.ChannelBase;
 import org.javacord.api.entity.permission.PermissionType;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.listener.ChannelAttachableListener;
 import org.javacord.api.listener.ObjectAttachableListener;
+import org.javacord.api.util.Specializable;
 import org.javacord.api.util.event.ListenerManager;
 
 import java.util.Collection;
@@ -18,7 +20,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * The class represents a channel.
  */
-public interface Channel extends DiscordEntity, UpdatableFromCache {
+public interface Channel extends DiscordEntity, UpdatableFromCache, ChannelBase, Specializable<ChannelBase> {
 
     /**
      * Gets the type of the channel.
@@ -33,10 +35,7 @@ public interface Channel extends DiscordEntity, UpdatableFromCache {
      * @return The channel as group channel.
      */
     default Optional<GroupChannel> asGroupChannel() {
-        if (this instanceof GroupChannel) {
-            return Optional.of((GroupChannel) this);
-        }
-        return Optional.empty();
+        return as(GroupChannel.class);
     }
 
     /**
@@ -45,10 +44,7 @@ public interface Channel extends DiscordEntity, UpdatableFromCache {
      * @return The channel as private channel.
      */
     default Optional<PrivateChannel> asPrivateChannel() {
-        if (this instanceof PrivateChannel) {
-            return Optional.of((PrivateChannel) this);
-        }
-        return Optional.empty();
+        return as(PrivateChannel.class);
     }
 
     /**
@@ -57,10 +53,7 @@ public interface Channel extends DiscordEntity, UpdatableFromCache {
      * @return The channel as server channel.
      */
     default Optional<ServerChannel> asServerChannel() {
-        if (this instanceof ServerChannel) {
-            return Optional.of((ServerChannel) this);
-        }
-        return Optional.empty();
+        return as(ServerChannel.class);
     }
 
     /**
@@ -69,10 +62,7 @@ public interface Channel extends DiscordEntity, UpdatableFromCache {
      * @return The channel as channel category.
      */
     default Optional<ChannelCategory> asChannelCategory() {
-        if (this instanceof ChannelCategory) {
-            return Optional.of((ChannelCategory) this);
-        }
-        return Optional.empty();
+        return as(ChannelCategory.class);
     }
 
     /**
@@ -81,10 +71,7 @@ public interface Channel extends DiscordEntity, UpdatableFromCache {
      * @return The channel as categorizable.
      */
     default Optional<Categorizable> asCategorizable() {
-        if (this instanceof Categorizable) {
-            return Optional.of((Categorizable) this);
-        }
-        return Optional.empty();
+        return as(Categorizable.class);
     }
 
     /**
@@ -93,10 +80,7 @@ public interface Channel extends DiscordEntity, UpdatableFromCache {
      * @return The channel as server text channel.
      */
     default Optional<ServerTextChannel> asServerTextChannel() {
-        if (this instanceof ServerTextChannel) {
-            return Optional.of((ServerTextChannel) this);
-        }
-        return Optional.empty();
+        return as(ServerTextChannel.class);
     }
 
     /**
@@ -105,10 +89,7 @@ public interface Channel extends DiscordEntity, UpdatableFromCache {
      * @return The channel as server voice channel.
      */
     default Optional<ServerVoiceChannel> asServerVoiceChannel() {
-        if (this instanceof ServerVoiceChannel) {
-            return Optional.of((ServerVoiceChannel) this);
-        }
-        return Optional.empty();
+        return as(ServerVoiceChannel.class);
     }
 
     /**
@@ -117,10 +98,7 @@ public interface Channel extends DiscordEntity, UpdatableFromCache {
      * @return The channel as text channel.
      */
     default Optional<TextChannel> asTextChannel() {
-        if (this instanceof TextChannel) {
-            return Optional.of((TextChannel) this);
-        }
-        return Optional.empty();
+        return as(TextChannel.class);
     }
 
     /**
@@ -129,10 +107,7 @@ public interface Channel extends DiscordEntity, UpdatableFromCache {
      * @return The channel as voice channel.
      */
     default Optional<VoiceChannel> asVoiceChannel() {
-        if (this instanceof VoiceChannel) {
-            return Optional.of((VoiceChannel) this);
-        }
-        return Optional.empty();
+        return as(VoiceChannel.class);
     }
 
 

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ChannelBase.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ChannelBase.java
@@ -1,0 +1,10 @@
+package org.javacord.api.entity.channel.internal;
+
+import org.javacord.api.util.Specializable;
+
+/**
+ * This interface is used to group the different channel interfaces to gain consistent methods for the
+ * {@link Specializable} interface.
+ */
+public interface ChannelBase {
+}

--- a/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ChannelBase.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/channel/internal/ChannelBase.java
@@ -1,10 +1,10 @@
 package org.javacord.api.entity.channel.internal;
 
-import org.javacord.api.util.Specializable;
+import org.javacord.api.util.Specifiable;
 
 /**
  * This interface is used to group the different channel interfaces to gain consistent methods for the
- * {@link Specializable} interface.
+ * {@link Specifiable} interface.
  */
 public interface ChannelBase {
 }

--- a/javacord-api/src/main/java/org/javacord/api/entity/emoji/Emoji.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/emoji/Emoji.java
@@ -1,13 +1,14 @@
 package org.javacord.api.entity.emoji;
 
 import org.javacord.api.entity.Mentionable;
+import org.javacord.api.util.Specializable;
 
 import java.util.Optional;
 
 /**
  * This class represents an emoji which can be a custom emoji (known or unknown) or a unicode emoji.
  */
-public interface Emoji extends Mentionable {
+public interface Emoji extends Mentionable, Specializable<Emoji> {
 
     /**
      * Gets the emoji as unicode emoji.
@@ -21,14 +22,18 @@ public interface Emoji extends Mentionable {
      *
      * @return The emoji as custom emoji.
      */
-    Optional<CustomEmoji> asCustomEmoji();
+    default Optional<CustomEmoji> asCustomEmoji() {
+        return as(CustomEmoji.class);
+    }
 
     /**
      * Gets the emoji as known custom emoji.
      *
      * @return The emoji as known custom emoji.
      */
-    Optional<KnownCustomEmoji> asKnownCustomEmoji();
+    default Optional<KnownCustomEmoji> asKnownCustomEmoji() {
+        return as(KnownCustomEmoji.class);
+    }
 
     /**
      * Checks if the emoji is equal to the given emoji.

--- a/javacord-api/src/main/java/org/javacord/api/entity/emoji/Emoji.java
+++ b/javacord-api/src/main/java/org/javacord/api/entity/emoji/Emoji.java
@@ -1,14 +1,14 @@
 package org.javacord.api.entity.emoji;
 
 import org.javacord.api.entity.Mentionable;
-import org.javacord.api.util.Specializable;
+import org.javacord.api.util.Specifiable;
 
 import java.util.Optional;
 
 /**
  * This class represents an emoji which can be a custom emoji (known or unknown) or a unicode emoji.
  */
-public interface Emoji extends Mentionable, Specializable<Emoji> {
+public interface Emoji extends Mentionable, Specifiable<Emoji> {
 
     /**
      * Gets the emoji as unicode emoji.

--- a/javacord-api/src/main/java/org/javacord/api/util/Specializable.java
+++ b/javacord-api/src/main/java/org/javacord/api/util/Specializable.java
@@ -1,0 +1,45 @@
+package org.javacord.api.util;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * This interface is used to provide a more stream lined way to interact with the instance as sub types.
+ * @param <S> Base instance type.
+ */
+public interface Specializable<S> {
+
+    /**
+     * Get an {@link Optional} instance of an instance as specified type.
+     * If the instance is not castable to the specified type, the {@link Optional} will be empty.
+     * @param type Specified type, this instance will be tried to casted to.
+     * @param instance Instance which will be tried to get casted.
+     * @param <T> Specified type.
+     * @return Returns an {@link Optional} of the specified type if the instance is castable, if not it returns an empty
+     *         {@link Optional}.
+     * @throws NullPointerException Throws a {@link NullPointerException} if either {@code type} or {@code instance} is
+     *                              {@code null}.
+     * @see java.util.Optional
+     */
+    static <T> Optional<T> tryToSpecify(Class<T> type, Object instance) {
+        Objects.requireNonNull(type, "type must not be null");
+        Objects.requireNonNull(instance, "instance must not be null");
+
+        return type.isAssignableFrom(instance.getClass()) ? Optional.of((T) instance) : Optional.empty();
+    }
+
+    /**
+     * Get an {@link Optional} of this instance as specified type.
+     * If the instance is not castable to the specified type, the {@link Optional} will be empty.
+     * @param type Specified type, this instance will be tried to casted to.
+     * @param <T> Specified type.
+     * @return Returns an {@link Optional} of the specified type if the instance is castable, if not it returns an empty
+     *         {@link Optional}.
+     * @see Specializable#tryToSpecify(Class, Object)
+     */
+    default <T extends S> Optional<T> as(Class<T> type) {
+        Objects.requireNonNull(type, "type must not be null");
+
+        return tryToSpecify(type, this);
+    }
+}

--- a/javacord-api/src/main/java/org/javacord/api/util/Specifiable.java
+++ b/javacord-api/src/main/java/org/javacord/api/util/Specifiable.java
@@ -7,7 +7,7 @@ import java.util.Optional;
  * This interface is used to provide a more stream lined way to interact with the instance as sub types.
  * @param <S> Base instance type.
  */
-public interface Specializable<S> {
+public interface Specifiable<S> {
 
     /**
      * Get an {@link Optional} instance of an instance as specified type.
@@ -35,7 +35,7 @@ public interface Specializable<S> {
      * @param <T> Specified type.
      * @return Returns an {@link Optional} of the specified type if the instance is castable, if not it returns an empty
      *         {@link Optional}.
-     * @see Specializable#tryToSpecify(Class, Object)
+     * @see Specifiable#tryToSpecify(Class, Object)
      */
     default <T extends S> Optional<T> as(Class<T> type) {
         Objects.requireNonNull(type, "type must not be null");


### PR DESCRIPTION
This will remove the maintenance overhead for the `Optional<Xyz> asXyz()` methods in `Channel` and `Emoji`.

It also introduces an internal `ChannelBase` interface, to make the API of the `Channel` interface more consistent.

For even more consitency I think it would be better to rename `Emoji.asUnicodeEmoji()` simply to `Emoji.asUnicode()` or `Emoji.asString()` (I would prefer the latter) (this is not part of the PR)