### PR TITLE
Make OkHttp release resources on disconnect

### DIFF
--- a/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
+++ b/javacord-core/src/main/java/org/javacord/core/DiscordApiImpl.java
@@ -1114,6 +1114,8 @@ public class DiscordApiImpl implements DiscordApi {
                     // shutdown thread pool if within one minute no disconnect event was dispatched
                     threadPool.getDaemonScheduler().schedule(threadPool::shutdown, 1, TimeUnit.MINUTES);
                 }
+                httpClient.dispatcher().executorService().shutdown();
+                httpClient.connectionPool().evictAll();
                 ratelimitManager.cleanup();
             }
             disconnectCalled = true;


### PR DESCRIPTION
Without this, OkHttp hangs when run on Java 9, as then their HTTP 2.0 implementation is used
where a non-daemon thread hangs and prevents orderly JVM shutdown for a significant amount of time.